### PR TITLE
feat: add supabase auth provider and email otp sign-in

### DIFF
--- a/app/(auth)/sign-in.tsx
+++ b/app/(auth)/sign-in.tsx
@@ -1,14 +1,37 @@
-import { View, Text, TextInput, Pressable } from 'react-native';
+import { useState } from 'react';
+import { View, Text, TextInput, Pressable, Alert } from 'react-native';
+import * as Linking from 'expo-linking';
 import supabase from '../../lib/supabase';
 
 export default function SignIn() {
+  const [email, setEmail] = useState('');
+
   return (
     <View style={{ flex: 1, padding: 16, justifyContent: 'center', gap: 12 }}>
       <Text style={{ fontSize: 24, fontWeight: '600' }}>Вход по email</Text>
-      <TextInput placeholder="email" keyboardType="email-address" autoCapitalize="none" style={{ backgroundColor: '#111', padding: 12, borderRadius: 12 }} />
-      <Pressable onPress={async () => {
-        // TODO: реализовать send magic link / OTP через supabase.auth
-      }} style={{ padding: 12, borderRadius: 12, backgroundColor: '#5dbea3' }}>
+      <TextInput
+        placeholder="email"
+        keyboardType="email-address"
+        autoCapitalize="none"
+        value={email}
+        onChangeText={setEmail}
+        style={{ backgroundColor: '#111', padding: 12, borderRadius: 12 }}
+      />
+      <Pressable
+        onPress={async () => {
+          const redirectTo = Linking.createURL('/auth');
+          const { error } = await supabase.auth.signInWithOtp({
+            email,
+            options: { emailRedirectTo: redirectTo },
+          });
+          if (error) {
+            Alert.alert('Ошибка', error.message);
+          } else {
+            Alert.alert('Проверьте почту', 'Мы отправили вам ссылку для входа.');
+          }
+        }}
+        style={{ padding: 12, borderRadius: 12, backgroundColor: '#5dbea3' }}
+      >
         <Text>Отправить код</Text>
       </Pressable>
     </View>

--- a/app/_layout.tsx
+++ b/app/_layout.tsx
@@ -1,12 +1,15 @@
 import { Stack } from 'expo-router';
+import { AuthProvider } from '../lib/auth';
 
 export default function RootLayout() {
   return (
-    <Stack screenOptions={{ headerShown: false }}>
-      <Stack.Screen name="(tabs)" />
-      <Stack.Screen name="(auth)/onboarding" options={{ presentation: 'modal' }} />
-      <Stack.Screen name="(auth)/sign-in" options={{ presentation: 'modal' }} />
-      <Stack.Screen name="chat/[id]" options={{ headerShown: true, title: 'Chat' }} />
-    </Stack>
+    <AuthProvider>
+      <Stack screenOptions={{ headerShown: false }}>
+        <Stack.Screen name="(tabs)" />
+        <Stack.Screen name="(auth)/onboarding" options={{ presentation: 'modal' }} />
+        <Stack.Screen name="(auth)/sign-in" options={{ presentation: 'modal' }} />
+        <Stack.Screen name="chat/[id]" options={{ headerShown: true, title: 'Chat' }} />
+      </Stack>
+    </AuthProvider>
   );
 }

--- a/lib/auth.tsx
+++ b/lib/auth.tsx
@@ -1,0 +1,37 @@
+import { createContext, useContext, useEffect, useState } from 'react';
+import type { Session } from '@supabase/supabase-js';
+import supabase from './supabase';
+
+interface AuthContextValue {
+  session: Session | null;
+}
+
+const AuthContext = createContext<AuthContextValue>({ session: null });
+
+export function AuthProvider({ children }: { children: React.ReactNode }) {
+  const [session, setSession] = useState<Session | null>(null);
+
+  useEffect(() => {
+    supabase.auth.getSession().then(({ data: { session } }) => {
+      setSession(session);
+    });
+
+    const { data: { subscription } } = supabase.auth.onAuthStateChange((_event, session) => {
+      setSession(session);
+    });
+
+    return () => {
+      subscription.unsubscribe();
+    };
+  }, []);
+
+  return (
+    <AuthContext.Provider value={{ session }}>
+      {children}
+    </AuthContext.Provider>
+  );
+}
+
+export function useAuth() {
+  return useContext(AuthContext);
+}


### PR DESCRIPTION
## Summary
- add AuthProvider subscribed to Supabase auth state changes
- wrap root layout with AuthProvider
- implement email OTP sign-in flow with redirect and error handling

## Testing
- `npm test` *(fails: Missing script "test")*
- `npx tsc --noEmit` *(fails: Cannot find module 'expo-web-browser')*


------
https://chatgpt.com/codex/tasks/task_e_68b0e6d622748327bf8ac79a88ef3a19