### PR TITLE
feat: add desktop responsive layout

### DIFF
--- a/app/(tabs)/inbox.tsx
+++ b/app/(tabs)/inbox.tsx
@@ -1,7 +1,16 @@
-import { View, Text } from 'react-native';
+import { View, Text, useWindowDimensions } from 'react-native';
+
 export default function Inbox() {
+  const { width } = useWindowDimensions();
+  const isDesktop = width >= 768;
+
   return (
-    <View style={{ flex: 1, padding: 16 }}>
+    <View
+      style={[
+        { flex: 1, padding: 16, width: '100%' },
+        isDesktop && { maxWidth: 600, alignSelf: 'center' },
+      ]}
+    >
       <Text style={{ fontSize: 24, fontWeight: '600' }}>Chats</Text>
       <Text style={{ marginTop: 8, opacity: 0.7 }}>Диалогов ещё нет</Text>
     </View>

--- a/app/(tabs)/index.tsx
+++ b/app/(tabs)/index.tsx
@@ -1,4 +1,4 @@
-import { View, Text, Pressable, Image } from 'react-native';
+import { View, Text, Pressable, Image, useWindowDimensions } from 'react-native';
 import { useState, useEffect } from 'react';
 import { useRouter } from 'expo-router';
 import supabase from '../../lib/supabase';
@@ -9,6 +9,8 @@ export default function Discover() {
   const [candidates, setCandidates] = useState<any[]>([]);
   const [showMatch, setShowMatch] = useState(false);
   const router = useRouter();
+  const { width } = useWindowDimensions();
+  const isDesktop = width >= 768;
 
   useEffect(() => {
     fetchCandidates().then(setCandidates).catch(() => setCandidates([]));
@@ -40,10 +42,26 @@ export default function Discover() {
     }
   };
   return (
-    <View style={{ flex: 1, padding: 16, gap: 16, justifyContent: 'center' }}>
+    <View
+      style={[
+        {
+          flex: 1,
+          padding: 16,
+          gap: 16,
+          justifyContent: 'center',
+          width: '100%',
+        },
+        isDesktop && { maxWidth: 600, alignSelf: 'center' },
+      ]}
+    >
       <Text style={{ fontSize: 24, fontWeight: '600' }}>Discover</Text>
       {c ? (
-        <View style={{ padding: 16, borderRadius: 16, backgroundColor: '#222' }}>
+        <View
+          style={[
+            { padding: 16, borderRadius: 16, backgroundColor: '#222', width: '100%' },
+            isDesktop && { maxWidth: 600, alignSelf: 'center' },
+          ]}
+        >
           {photo ? (
             <Image
               source={{ uri: photo }}

--- a/app/(tabs)/matches.tsx
+++ b/app/(tabs)/matches.tsx
@@ -1,7 +1,16 @@
-import { View, Text } from 'react-native';
+import { View, Text, useWindowDimensions } from 'react-native';
+
 export default function Matches() {
+  const { width } = useWindowDimensions();
+  const isDesktop = width >= 768;
+
   return (
-    <View style={{ flex: 1, padding: 16 }}>
+    <View
+      style={[
+        { flex: 1, padding: 16, width: '100%' },
+        isDesktop && { maxWidth: 600, alignSelf: 'center' },
+      ]}
+    >
       <Text style={{ fontSize: 24, fontWeight: '600' }}>Matches</Text>
       <Text style={{ marginTop: 8, opacity: 0.7 }}>Пока пусто</Text>
     </View>

--- a/app/(tabs)/profile.tsx
+++ b/app/(tabs)/profile.tsx
@@ -1,5 +1,5 @@
 import { useEffect, useState } from 'react';
-import { View, Text, TextInput, Button, Image } from 'react-native';
+import { View, Text, TextInput, Button, Image, useWindowDimensions } from 'react-native';
 import * as ImagePicker from 'expo-image-picker';
 import supabase from '../../lib/supabase';
 import { useAuth } from '../../lib/auth';
@@ -7,6 +7,8 @@ import { useAuth } from '../../lib/auth';
 export default function Profile() {
   const { session } = useAuth();
   const [photoUrl, setPhotoUrl] = useState<string | null>(null);
+  const { width } = useWindowDimensions();
+  const isDesktop = width >= 768;
 
   useEffect(() => {
     if (!session?.user) return;
@@ -57,7 +59,12 @@ export default function Profile() {
   };
 
   return (
-    <View style={{ flex: 1, padding: 16, gap: 12 }}>
+    <View
+      style={[
+        { flex: 1, padding: 16, gap: 12, width: '100%' },
+        isDesktop && { maxWidth: 600, alignSelf: 'center' },
+      ]}
+    >
       <Text style={{ fontSize: 24, fontWeight: '600' }}>Your profile</Text>
       {photoUrl && (
         <Image

--- a/app/(tabs)/two.tsx
+++ b/app/(tabs)/two.tsx
@@ -1,11 +1,14 @@
-import { StyleSheet } from 'react-native';
+import { StyleSheet, useWindowDimensions } from 'react-native';
 
 import EditScreenInfo from '@/components/EditScreenInfo';
 import { Text, View } from '@/components/Themed';
 
 export default function TabTwoScreen() {
+  const { width } = useWindowDimensions();
+  const isDesktop = width >= 768;
+
   return (
-    <View style={styles.container}>
+    <View style={[styles.container, isDesktop && { width: '100%', maxWidth: 600, alignSelf: 'center' }]}>
       <Text style={styles.title}>Tab Two</Text>
       <View style={styles.separator} lightColor="#eee" darkColor="rgba(255,255,255,0.1)" />
       <EditScreenInfo path="app/(tabs)/two.tsx" />

--- a/components/ui/Button.tsx
+++ b/components/ui/Button.tsx
@@ -1,8 +1,18 @@
-import { Pressable, Text, ViewStyle } from 'react-native';
+import { Pressable, Text, ViewStyle, useWindowDimensions } from 'react-native';
 
 export default function Button({ title, onPress, style }: { title: string; onPress?: () => void; style?: ViewStyle }) {
+  const { width } = useWindowDimensions();
+  const isDesktop = width >= 768;
+
   return (
-    <Pressable onPress={onPress} style={[{ padding: 12, borderRadius: 12, backgroundColor: '#5dbea3', alignItems: 'center' }, style]}>
+    <Pressable
+      onPress={onPress}
+      style={[
+        { padding: 12, borderRadius: 12, backgroundColor: '#5dbea3', alignItems: 'center', alignSelf: 'flex-start' },
+        isDesktop && { alignSelf: 'center', width: '100%', maxWidth: 200 },
+        style,
+      ]}
+    >
       <Text style={{ fontWeight: '600' }}>{title}</Text>
     </Pressable>
   );

--- a/components/ui/Card.tsx
+++ b/components/ui/Card.tsx
@@ -1,6 +1,18 @@
-import { View, ViewStyle } from 'react-native';
+import { View, ViewStyle, useWindowDimensions } from 'react-native';
+
 export default function Card({ children, style }: { children: React.ReactNode; style?: ViewStyle }) {
+  const { width } = useWindowDimensions();
+  const isDesktop = width >= 768;
+
   return (
-    <View style={[{ padding: 16, borderRadius: 16, backgroundColor: '#222' }, style]}>{children}</View>
+    <View
+      style={[
+        { padding: 16, borderRadius: 16, backgroundColor: '#222', width: '100%' },
+        isDesktop && { maxWidth: 600, alignSelf: 'center' },
+        style,
+      ]}
+    >
+      {children}
+    </View>
   );
 }


### PR DESCRIPTION
## Summary
- center and cap width for shared Button and Card components on desktop
- apply responsive max-width containers to tab screens using `useWindowDimensions`

## Testing
- `npm test` *(fails: Missing script: "test")*

------
https://chatgpt.com/codex/tasks/task_e_68b1ebb055a08327bf7bd0e7ba37a7f1