### PR TITLE
Verify Supabase environment variables before client creation

### DIFF
--- a/lib/supabase.ts
+++ b/lib/supabase.ts
@@ -1,7 +1,17 @@
 import { createClient } from '@supabase/supabase-js';
 
-const supabaseUrl = process.env.EXPO_PUBLIC_SUPABASE_URL as string;
-const supabaseAnon = process.env.EXPO_PUBLIC_SUPABASE_ANON_KEY as string;
+// Retrieve environment variables at runtime
+const supabaseUrl = process.env.EXPO_PUBLIC_SUPABASE_URL;
+const supabaseAnonKey = process.env.EXPO_PUBLIC_SUPABASE_ANON_KEY;
 
-export const supabase = createClient(supabaseUrl, supabaseAnon);
+// Ensure both required environment variables are present before creating the client
+if (!supabaseUrl || !supabaseAnonKey) {
+  const missing = [
+    !supabaseUrl && 'EXPO_PUBLIC_SUPABASE_URL',
+    !supabaseAnonKey && 'EXPO_PUBLIC_SUPABASE_ANON_KEY',
+  ].filter(Boolean);
+  throw new Error(`Missing environment variables: ${missing.join(', ')}`);
+}
+
+export const supabase = createClient(supabaseUrl, supabaseAnonKey);
 export default supabase;


### PR DESCRIPTION
## Summary
- check for `EXPO_PUBLIC_SUPABASE_URL` and `EXPO_PUBLIC_SUPABASE_ANON_KEY`
- throw descriptive error when required variables are missing
- create Supabase client only after verification

## Testing
- `npm test` *(fails: Missing script "test")*
- `npx tsc -p tsconfig.json --noEmit` *(fails: Unused '@ts-expect-error' directive in components/ExternalLink.tsx)*

------
https://chatgpt.com/codex/tasks/task_e_68b4546bd71c83279f939fc735a0cef5