### PR TITLE
feat: fetch candidates from edge function

### DIFF
--- a/lib/api.ts
+++ b/lib/api.ts
@@ -1,10 +1,41 @@
 import supabase from './supabase';
 
-export async function fetchCandidates() {
-  // TODO: заменить на вызов Edge Function с фильтрами по локации/целям/времени
-  return [
-    { id: 'u1', name: 'Anna, 24', about: 'Кино, кошки, кофе' },
-  ];
+export interface CandidateFilters {
+  /**
+   * Geolocation information used to scope the search.
+   * `radiusKm` is optional and defaults to server-side settings.
+   */
+  location?: { lat: number; lng: number; radiusKm?: number };
+  /**
+   * Preferred meeting goals such as "coffee" or "walk".
+   */
+  goals?: string[];
+  /**
+   * Time slots when the user is available.
+   */
+  availability?: { day: string; from: string; to: string }[];
+}
+
+/**
+ * Fetch potential matches from the backend.
+ *
+ * @throws {Error} When the request fails or the backend returns an error.
+ */
+export async function fetchCandidates(filters: CandidateFilters = {}) {
+  try {
+    const { data, error } = await supabase.functions.invoke('fetch-candidates', {
+      body: filters,
+    });
+
+    if (error) {
+      throw new Error(error.message || 'Unknown error');
+    }
+
+    return data as any[];
+  } catch (err) {
+    const message = err instanceof Error ? err.message : String(err);
+    throw new Error(`Failed to fetch candidates: ${message}`);
+  }
 }
 
 export async function aiIcebreaker(matchId: string) {


### PR DESCRIPTION
## Summary
- replace hardcoded candidate array with Edge Function request
- accept location, goals and availability filters in API
- add error handling and meaningful exceptions

## Testing
- `npm test` *(fails: Missing script "test")*
- `npx tsc --noEmit` *(fails: Cannot find module 'expo-web-browser')*

------
https://chatgpt.com/codex/tasks/task_e_68b4556445f483279957e55b4adedc4a