### PR TITLE
Request media library permissions before image upload

### DIFF
--- a/app/(tabs)/profile.tsx
+++ b/app/(tabs)/profile.tsx
@@ -1,5 +1,5 @@
 import { useEffect, useState } from 'react';
-import { View, Text, TextInput, Button, Image, useWindowDimensions } from 'react-native';
+import { View, Text, TextInput, Button, Image, useWindowDimensions, Alert } from 'react-native';
 import * as ImagePicker from 'expo-image-picker';
 import supabase from '../../lib/supabase';
 import { useAuth } from '../../lib/auth';
@@ -27,6 +27,14 @@ export default function Profile() {
 
   const pickImage = async () => {
     if (!session?.user) return;
+    const permission = await ImagePicker.requestMediaLibraryPermissionsAsync();
+    if (!permission.granted) {
+      Alert.alert(
+        'Permission required',
+        'Please allow access to your media library to upload a photo.',
+      );
+      return;
+    }
     const result = await ImagePicker.launchImageLibraryAsync({
       mediaTypes: ImagePicker.MediaTypeOptions.Images,
       quality: 1,


### PR DESCRIPTION
## Summary
- Request media library permissions before picking a profile image
- Show an alert and abort if permissions are denied

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run ios` *(fails: iOS apps can only be built on macOS devices)*
- `CI=1 npm run android` *(fails: Failed to resolve the Android SDK path)*

------
https://chatgpt.com/codex/tasks/task_e_68b45da0ddbc8327b66ced2731b98dcc