### PR TITLE
feat: add responsive sidebar navigation

### DIFF
--- a/app/(tabs)/_layout.tsx
+++ b/app/(tabs)/_layout.tsx
@@ -1,33 +1,53 @@
-import { Tabs } from 'expo-router';
+import { Tabs, Stack } from 'expo-router';
 import { Ionicons } from '@expo/vector-icons';
+import { useWindowDimensions } from 'react-native';
 
 export default function TabsLayout() {
+  const { width } = useWindowDimensions();
+  const isDesktop = width >= 768;
+
+  if (isDesktop) {
+    return <Stack screenOptions={{ headerTitleAlign: 'center' }} />;
+  }
+
   return (
     <Tabs screenOptions={{ headerTitleAlign: 'center' }}>
-      <Tabs.Screen name="index" options={{
-        title: 'Discover',
-        tabBarIcon: ({ color, size }) => (
-          <Ionicons name="compass-outline" size={size} color={color} />
-        ),
-      }} />
-      <Tabs.Screen name="matches" options={{
-        title: 'Matches',
-        tabBarIcon: ({ color, size }) => (
-          <Ionicons name="heart-outline" size={size} color={color} />
-        ),
-      }} />
-      <Tabs.Screen name="inbox" options={{
-        title: 'Chats',
-        tabBarIcon: ({ color, size }) => (
-          <Ionicons name="chatbubble-ellipses-outline" size={size} color={color} />
-        ),
-      }} />
-      <Tabs.Screen name="profile" options={{
-        title: 'Profile',
-        tabBarIcon: ({ color, size }) => (
-          <Ionicons name="person-circle-outline" size={size} color={color} />
-        ),
-      }} />
+      <Tabs.Screen
+        name="index"
+        options={{
+          title: 'Discover',
+          tabBarIcon: ({ color, size }) => (
+            <Ionicons name="compass-outline" size={size} color={color} />
+          ),
+        }}
+      />
+      <Tabs.Screen
+        name="matches"
+        options={{
+          title: 'Matches',
+          tabBarIcon: ({ color, size }) => (
+            <Ionicons name="heart-outline" size={size} color={color} />
+          ),
+        }}
+      />
+      <Tabs.Screen
+        name="inbox"
+        options={{
+          title: 'Chats',
+          tabBarIcon: ({ color, size }) => (
+            <Ionicons name="chatbubble-ellipses-outline" size={size} color={color} />
+          ),
+        }}
+      />
+      <Tabs.Screen
+        name="profile"
+        options={{
+          title: 'Profile',
+          tabBarIcon: ({ color, size }) => (
+            <Ionicons name="person-circle-outline" size={size} color={color} />
+          ),
+        }}
+      />
     </Tabs>
   );
 }

--- a/app/_layout.tsx
+++ b/app/_layout.tsx
@@ -1,15 +1,25 @@
 import { Stack } from 'expo-router';
 import { AuthProvider } from '../lib/auth';
+import { View, useWindowDimensions } from 'react-native';
+import Sidebar from '../components/Sidebar';
 
 export default function RootLayout() {
+  const { width } = useWindowDimensions();
+  const isDesktop = width >= 768;
+
   return (
     <AuthProvider>
-      <Stack screenOptions={{ headerShown: false }}>
-        <Stack.Screen name="(tabs)" />
-        <Stack.Screen name="(auth)/onboarding" options={{ presentation: 'modal' }} />
-        <Stack.Screen name="(auth)/sign-in" options={{ presentation: 'modal' }} />
-        <Stack.Screen name="chat/[id]" options={{ headerShown: true, title: 'Chat' }} />
-      </Stack>
+      <View style={{ flexDirection: 'row', flex: 1 }}>
+        {isDesktop && <Sidebar />}
+        <View style={{ flex: 1 }}>
+          <Stack screenOptions={{ headerShown: false }}>
+            <Stack.Screen name="(tabs)" />
+            <Stack.Screen name="(auth)/onboarding" options={{ presentation: 'modal' }} />
+            <Stack.Screen name="(auth)/sign-in" options={{ presentation: 'modal' }} />
+            <Stack.Screen name="chat/[id]" options={{ headerShown: true, title: 'Chat' }} />
+          </Stack>
+        </View>
+      </View>
     </AuthProvider>
   );
 }

--- a/components/Sidebar.tsx
+++ b/components/Sidebar.tsx
@@ -1,0 +1,47 @@
+import { View, Text, Pressable, StyleSheet } from 'react-native';
+import { Link, usePathname } from 'expo-router';
+
+const items = [
+  { href: '/', label: 'Discover' },
+  { href: '/matches', label: 'Matches' },
+  { href: '/inbox', label: 'Chats' },
+  { href: '/profile', label: 'Profile' },
+];
+
+export default function Sidebar() {
+  const pathname = usePathname();
+
+  return (
+    <View style={styles.container}>
+      {items.map((item) => {
+        const active = pathname === item.href;
+        return (
+          <Link key={item.href} href={item.href} asChild>
+            <Pressable style={[styles.item, active && styles.activeItem]}>
+              <Text style={styles.itemText}>{item.label}</Text>
+            </Pressable>
+          </Link>
+        );
+      })}
+    </View>
+  );
+}
+
+const styles = StyleSheet.create({
+  container: {
+    width: 280,
+    backgroundColor: '#202123',
+    paddingTop: 24,
+  },
+  item: {
+    paddingVertical: 12,
+    paddingHorizontal: 16,
+  },
+  activeItem: {
+    backgroundColor: '#343541',
+  },
+  itemText: {
+    color: '#fff',
+    fontSize: 16,
+  },
+});


### PR DESCRIPTION
## Summary
- add desktop sidebar with navigation links and active styling
- restructure root layout to place sidebar beside content
- switch between stack and tab navigation depending on screen width

## Testing
- `npm test` *(fails: Missing script: "test")*

------
https://chatgpt.com/codex/tasks/task_e_68b466f756188327816a0890398f7007