### PR TITLE
feat: fallback candidates to sample data

### DIFF
--- a/app/(tabs)/index.tsx
+++ b/app/(tabs)/index.tsx
@@ -86,6 +86,11 @@ export default function Discover() {
           )}
           <Text style={{ fontSize: 20, marginBottom: 8 }}>{c.name ?? 'Без имени'}</Text>
           <Text style={{ opacity: 0.7 }}>{c.bio ?? 'Нет информации о себе'}</Text>
+          {c.coordinates && (
+            <Text style={{ opacity: 0.7 }}>
+              {`Координаты: ${c.coordinates.lat}, ${c.coordinates.lng}`}
+            </Text>
+          )}
         </View>
       ) : (
         <Text>Больше кандидатов нет</Text>

--- a/lib/api.ts
+++ b/lib/api.ts
@@ -1,4 +1,7 @@
 import supabase from './supabase';
+import { sampleProfiles } from './sample-data';
+
+const USE_SAMPLE_DATA = process.env.EXPO_PUBLIC_USE_SAMPLE_DATA === 'true';
 
 export interface CandidateFilters {
   /**
@@ -22,19 +25,23 @@ export interface CandidateFilters {
  * @throws {Error} When the request fails or the backend returns an error.
  */
 export async function fetchCandidates(filters: CandidateFilters = {}) {
+  if (USE_SAMPLE_DATA) {
+    return sampleProfiles;
+  }
   try {
     const { data, error } = await supabase.functions.invoke('fetch-candidates', {
       body: filters,
     });
 
     if (error) {
-      throw new Error(error.message || 'Unknown error');
+      console.error(error);
+      return sampleProfiles;
     }
 
     return data as any[];
   } catch (err) {
-    const message = err instanceof Error ? err.message : String(err);
-    throw new Error(`Failed to fetch candidates: ${message}`);
+    console.error(err);
+    return sampleProfiles;
   }
 }
 

--- a/lib/sample-data.ts
+++ b/lib/sample-data.ts
@@ -1,0 +1,25 @@
+import type { Profile } from './types';
+
+export const sampleProfiles: Profile[] = [
+  {
+    id: '1',
+    name: 'Анна',
+    bio: 'Люблю чтение и прогулки.',
+    photos: ['https://example.com/photo1.jpg'],
+    coordinates: { lat: 55.751244, lng: 37.618423 },
+  },
+  {
+    id: '2',
+    name: 'Борис',
+    bio: 'Писатель и путешественник.',
+    photos: ['https://example.com/photo2.jpg'],
+    coordinates: { lat: 59.93428, lng: 30.335099 },
+  },
+  {
+    id: '3',
+    name: 'Катя',
+    bio: 'Увлекаюсь спортом и искусством.',
+    photos: ['https://example.com/photo3.jpg'],
+    coordinates: { lat: 56.838926, lng: 60.605703 },
+  },
+];

--- a/lib/types.ts
+++ b/lib/types.ts
@@ -3,6 +3,7 @@ export type Profile = {
   name: string;
   bio?: string;
   photos: string[];
+  coordinates?: { lat: number; lng: number };
   age?: number;
   goals?: string[]; // coffee | walk | home | party | etc
   radiusKm?: number;


### PR DESCRIPTION
## Summary
- add sample profile dataset with coordinates
- return sample profiles when Supabase fails or sample-data flag is set
- show candidate coordinates in Discover tab

## Testing
- `npm test` *(fails: Missing script "test")*


------
https://chatgpt.com/codex/tasks/task_e_68b4685864a48327a68897d876704fe8