### PR TITLE
Add sample messages fallback and mark AI icebreaker

### DIFF
--- a/lib/sample-messages.ts
+++ b/lib/sample-messages.ts
@@ -1,0 +1,38 @@
+export interface Message {
+  id: string;
+  match_id: string;
+  sender: string;
+  content: string;
+  created_at: string;
+}
+
+export const sampleMessages: Message[] = [
+  {
+    id: '1',
+    match_id: '1',
+    sender: 'user1',
+    content: 'Привет! Как твой день?',
+    created_at: '2024-01-01T10:00:00Z',
+  },
+  {
+    id: '2',
+    match_id: '1',
+    sender: 'user2',
+    content: 'Отлично, а у тебя?',
+    created_at: '2024-01-01T10:05:00Z',
+  },
+  {
+    id: '3',
+    match_id: '2',
+    sender: 'user1',
+    content: 'Любишь ли ты путешествовать?',
+    created_at: '2024-01-02T09:00:00Z',
+  },
+  {
+    id: '4',
+    match_id: '2',
+    sender: 'user3',
+    content: 'Да, очень!',
+    created_at: '2024-01-02T09:10:00Z',
+  },
+];


### PR DESCRIPTION
## Summary
- add reusable sample message dataset
- use sample messages when demo mode or no Supabase data
- style AI icebreaker to show it's only a sample

## Testing
- `npm test` *(fails: Missing script: "test")*
- `npx tsc --noEmit` *(fails: Cannot find module 'expo-web-browser')*

------
https://chatgpt.com/codex/tasks/task_e_68b4696926748327bc31d5c4e7e6e772