### PR TITLE
Add map tab and map screen with markers

### DIFF
--- a/app/(tabs)/_layout.tsx
+++ b/app/(tabs)/_layout.tsx
@@ -22,6 +22,15 @@ export default function TabsLayout() {
         }}
       />
       <Tabs.Screen
+        name="map"
+        options={{
+          title: 'Map',
+          tabBarIcon: ({ color, size }) => (
+            <Ionicons name="map-outline" size={size} color={color} />
+          ),
+        }}
+      />
+      <Tabs.Screen
         name="matches"
         options={{
           title: 'Matches',

--- a/app/(tabs)/index.tsx
+++ b/app/(tabs)/index.tsx
@@ -55,7 +55,12 @@ export default function Discover() {
         isDesktop && { maxWidth: 600, alignSelf: 'center' },
       ]}
     >
-      <Text style={{ fontSize: 24, fontWeight: '600' }}>Discover</Text>
+      <View style={{ flexDirection: 'row', justifyContent: 'space-between', alignItems: 'center' }}>
+        <Text style={{ fontSize: 24, fontWeight: '600' }}>Discover</Text>
+        <Pressable onPress={() => router.push('/(tabs)/map')}>
+          <Text style={{ color: '#5dbea3' }}>Map</Text>
+        </Pressable>
+      </View>
       {c ? (
         <View
           style={[

--- a/app/(tabs)/map.tsx
+++ b/app/(tabs)/map.tsx
@@ -1,0 +1,41 @@
+import { View, useWindowDimensions } from 'react-native';
+import MapView, { Marker } from 'react-native-maps';
+import { sampleProfiles } from '../../lib/sample-data';
+
+export default function MapScreen() {
+  const { width } = useWindowDimensions();
+  const isDesktop = width >= 768;
+
+  const first = sampleProfiles[0]?.coordinates ?? { lat: 0, lng: 0 };
+  const initialRegion = {
+    latitude: first.lat,
+    longitude: first.lng,
+    latitudeDelta: 5,
+    longitudeDelta: 5,
+  };
+
+  return (
+    <View
+      style={[
+        { flex: 1, width: '100%' },
+        isDesktop && { maxWidth: 600, alignSelf: 'center' },
+      ]}
+    >
+      <MapView style={{ flex: 1 }} initialRegion={initialRegion}>
+        {sampleProfiles.map((p) =>
+          p.coordinates ? (
+            <Marker
+              key={p.id}
+              coordinate={{
+                latitude: p.coordinates.lat,
+                longitude: p.coordinates.lng,
+              }}
+              title={p.name}
+              description={p.bio}
+            />
+          ) : null
+        )}
+      </MapView>
+    </View>
+  );
+}

--- a/components/ExternalLink.tsx
+++ b/components/ExternalLink.tsx
@@ -10,7 +10,6 @@ export function ExternalLink(
     <Link
       target="_blank"
       {...props}
-      // @ts-expect-error: External URLs are not typed.
       href={props.href}
       onPress={(e) => {
         if (Platform.OS !== 'web') {

--- a/package-lock.json
+++ b/package-lock.json
@@ -14,9 +14,11 @@
         "expo-image-picker": "16.1.4",
         "expo-router": "5.1.5",
         "expo-status-bar": "2.2.3",
+        "expo-web-browser": "^14.2.0",
         "react": "19.0.0",
         "react-dom": "19.0.0",
         "react-native": "0.79.6",
+        "react-native-maps": "^1.25.4",
         "react-native-safe-area-context": "5.4.0",
         "react-native-screens": "4.11.1",
         "react-native-web": "0.20.0"
@@ -24,6 +26,7 @@
       "devDependencies": {
         "@types/react": "19.0.14",
         "@types/react-native": "0.72.8",
+        "@types/react-native-maps": "^0.24.1",
         "typescript": "5.8.3"
       }
     },
@@ -2882,6 +2885,12 @@
         "@babel/types": "^7.28.2"
       }
     },
+    "node_modules/@types/geojson": {
+      "version": "7946.0.16",
+      "resolved": "https://registry.npmjs.org/@types/geojson/-/geojson-7946.0.16.tgz",
+      "integrity": "sha512-6C8nqWur3j98U6+lXDfTUWIfgvZU+EumvpHKcYjujKH7woYyLj2sUmff0tRhrqM7BohUw7Pz3ZB1jj2gW9Fvmg==",
+      "license": "MIT"
+    },
     "node_modules/@types/graceful-fs": {
       "version": "4.1.9",
       "resolved": "https://registry.npmjs.org/@types/graceful-fs/-/graceful-fs-4.1.9.tgz",
@@ -2949,6 +2958,17 @@
       "dependencies": {
         "@react-native/virtualized-lists": "^0.72.4",
         "@types/react": "*"
+      }
+    },
+    "node_modules/@types/react-native-maps": {
+      "version": "0.24.1",
+      "resolved": "https://registry.npmjs.org/@types/react-native-maps/-/react-native-maps-0.24.1.tgz",
+      "integrity": "sha512-5yAoJOnjwVRyK8iGGxN7d1ZNbxptHFeEgZKv1iZSAE76lgP22x5uXL3CV9JuCgzp3pvRQMC35xFk/9i5McfItA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/react": "*",
+        "@types/react-native": "*"
       }
     },
     "node_modules/@types/stack-utils": {
@@ -4507,6 +4527,16 @@
       },
       "peerDependencies": {
         "react": "*",
+        "react-native": "*"
+      }
+    },
+    "node_modules/expo-web-browser": {
+      "version": "14.2.0",
+      "resolved": "https://registry.npmjs.org/expo-web-browser/-/expo-web-browser-14.2.0.tgz",
+      "integrity": "sha512-6S51d8pVlDRDsgGAp8BPpwnxtyKiMWEFdezNz+5jVIyT+ctReW42uxnjRgtsdn5sXaqzhaX+Tzk/CWaKCyC0hw==",
+      "license": "MIT",
+      "peerDependencies": {
+        "expo": "*",
         "react-native": "*"
       }
     },
@@ -7093,6 +7123,28 @@
       "peerDependencies": {
         "react": "*",
         "react-native": "*"
+      }
+    },
+    "node_modules/react-native-maps": {
+      "version": "1.25.4",
+      "resolved": "https://registry.npmjs.org/react-native-maps/-/react-native-maps-1.25.4.tgz",
+      "integrity": "sha512-QgF0vAR6TKwwwcA4bDZXCACw+Z/05uhQTtq9mV7rXv8ABHz9FvuGtoZO2PPJ8iCsQFM56QxlO8MrEK8einA/fg==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/geojson": "^7946.0.13"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "peerDependencies": {
+        "react": ">= 18.3.1",
+        "react-native": ">= 0.76.0",
+        "react-native-web": ">= 0.11"
+      },
+      "peerDependenciesMeta": {
+        "react-native-web": {
+          "optional": true
+        }
       }
     },
     "node_modules/react-native-reanimated": {

--- a/package.json
+++ b/package.json
@@ -16,16 +16,19 @@
     "expo-image-picker": "16.1.4",
     "expo-router": "5.1.5",
     "expo-status-bar": "2.2.3",
+    "expo-web-browser": "^14.2.0",
     "react": "19.0.0",
+    "react-dom": "19.0.0",
     "react-native": "0.79.6",
+    "react-native-maps": "^1.25.4",
     "react-native-safe-area-context": "5.4.0",
     "react-native-screens": "4.11.1",
-    "react-dom": "19.0.0",
     "react-native-web": "0.20.0"
   },
   "devDependencies": {
     "@types/react": "19.0.14",
     "@types/react-native": "0.72.8",
+    "@types/react-native-maps": "^0.24.1",
     "typescript": "5.8.3"
   }
 }


### PR DESCRIPTION
## Summary
- install react-native-maps and related types
- add Map screen rendering markers from sample data
- add Map tab and navigation button from Discover
- include expo-web-browser and clean up ExternalLink for type checks

## Testing
- `npm test` (fails: Missing script)
- `npx tsc -p tsconfig.json --noEmit`


------
https://chatgpt.com/codex/tasks/task_e_68b46a0f087c8327a64e52b134d374d2