### PR TITLE
feat: add settings screen and preferences storage

### DIFF
--- a/app/(tabs)/_layout.tsx
+++ b/app/(tabs)/_layout.tsx
@@ -57,6 +57,15 @@ export default function TabsLayout() {
           ),
         }}
       />
+      <Tabs.Screen
+        name="settings"
+        options={{
+          title: 'Settings',
+          tabBarIcon: ({ color, size }) => (
+            <Ionicons name="settings-outline" size={size} color={color} />
+          ),
+        }}
+      />
     </Tabs>
   );
 }

--- a/app/(tabs)/settings.tsx
+++ b/app/(tabs)/settings.tsx
@@ -1,0 +1,75 @@
+import { useEffect, useState } from 'react';
+import { View, Text, Switch, Button, useWindowDimensions } from 'react-native';
+import { Picker } from '@react-native-picker/picker';
+import { loadPreferences, savePreferences, resetPreferences, Preferences } from '../../lib/preferences';
+
+export default function Settings() {
+  const { width } = useWindowDimensions();
+  const isDesktop = width >= 768;
+
+  const [prefs, setPrefs] = useState<Preferences>({
+    radius: 10,
+    goal: 'serious',
+    notifications: true,
+  });
+
+  useEffect(() => {
+    loadPreferences().then(setPrefs);
+  }, []);
+
+  return (
+    <View
+      style={[
+        { flex: 1, padding: 16, gap: 12, width: '100%' },
+        isDesktop && { maxWidth: 600, alignSelf: 'center' },
+      ]}
+    >
+      <Text style={{ fontSize: 24, fontWeight: '600' }}>Settings</Text>
+
+      <Text>Search radius</Text>
+      <Picker
+        selectedValue={prefs.radius}
+        onValueChange={(value) => setPrefs({ ...prefs, radius: value })}
+        style={{ backgroundColor: '#111', borderRadius: 12 }}
+      >
+        <Picker.Item label="5 km" value={5} />
+        <Picker.Item label="10 km" value={10} />
+        <Picker.Item label="20 km" value={20} />
+        <Picker.Item label="50 km" value={50} />
+      </Picker>
+
+      <Text>Dating goal</Text>
+      <Picker
+        selectedValue={prefs.goal}
+        onValueChange={(value) => setPrefs({ ...prefs, goal: value })}
+        style={{ backgroundColor: '#111', borderRadius: 12 }}
+      >
+        <Picker.Item label="Serious relationship" value="serious" />
+        <Picker.Item label="Casual dating" value="casual" />
+        <Picker.Item label="Friendship" value="friendship" />
+      </Picker>
+
+      <View style={{ flexDirection: 'row', alignItems: 'center', justifyContent: 'space-between' }}>
+        <Text>Notifications</Text>
+        <Switch
+          value={prefs.notifications}
+          onValueChange={(value) => setPrefs({ ...prefs, notifications: value })}
+        />
+      </View>
+
+      <Button
+        title="Save"
+        onPress={async () => {
+          await savePreferences(prefs);
+        }}
+      />
+      <Button
+        title="Reset"
+        onPress={async () => {
+          const defaults = await resetPreferences();
+          setPrefs(defaults);
+        }}
+      />
+    </View>
+  );
+}

--- a/lib/preferences.ts
+++ b/lib/preferences.ts
@@ -1,0 +1,44 @@
+import AsyncStorage from '@react-native-async-storage/async-storage';
+
+export interface Preferences {
+  radius: number;
+  goal: string;
+  notifications: boolean;
+}
+
+const DEFAULT_PREFERENCES: Preferences = {
+  radius: 10,
+  goal: 'serious',
+  notifications: true,
+};
+
+const STORAGE_KEY = 'preferences';
+
+export async function loadPreferences(): Promise<Preferences> {
+  try {
+    const stored = await AsyncStorage.getItem(STORAGE_KEY);
+    if (stored) {
+      return JSON.parse(stored);
+    }
+  } catch (e) {
+    console.error('Failed to load preferences', e);
+  }
+  return DEFAULT_PREFERENCES;
+}
+
+export async function savePreferences(prefs: Preferences): Promise<void> {
+  try {
+    await AsyncStorage.setItem(STORAGE_KEY, JSON.stringify(prefs));
+  } catch (e) {
+    console.error('Failed to save preferences', e);
+  }
+}
+
+export async function resetPreferences(): Promise<Preferences> {
+  try {
+    await AsyncStorage.removeItem(STORAGE_KEY);
+  } catch (e) {
+    console.error('Failed to reset preferences', e);
+  }
+  return DEFAULT_PREFERENCES;
+}

--- a/package-lock.json
+++ b/package-lock.json
@@ -9,6 +9,8 @@
       "version": "0.1.0",
       "dependencies": {
         "@expo/vector-icons": "14.1.0",
+        "@react-native-async-storage/async-storage": "^1.23.1",
+        "@react-native-picker/picker": "^2.7.5",
         "@supabase/supabase-js": "2.56.0",
         "expo": "53.0.22",
         "expo-image-picker": "16.1.4",
@@ -2351,6 +2353,31 @@
         "@types/react": {
           "optional": true
         }
+      }
+    },
+    "node_modules/@react-native-async-storage/async-storage": {
+      "version": "1.24.0",
+      "resolved": "https://registry.npmjs.org/@react-native-async-storage/async-storage/-/async-storage-1.24.0.tgz",
+      "integrity": "sha512-W4/vbwUOYOjco0x3toB8QCr7EjIP6nE9G7o8PMguvvjYT5Awg09lyV4enACRx4s++PPulBiBSjL0KTFx2u0Z/g==",
+      "license": "MIT",
+      "dependencies": {
+        "merge-options": "^3.0.4"
+      },
+      "peerDependencies": {
+        "react-native": "^0.0.0-0 || >=0.60 <1.0"
+      }
+    },
+    "node_modules/@react-native-picker/picker": {
+      "version": "2.11.1",
+      "resolved": "https://registry.npmjs.org/@react-native-picker/picker/-/picker-2.11.1.tgz",
+      "integrity": "sha512-ThklnkK4fV3yynnIIRBkxxjxR4IFbdMNJVF6tlLdOJ/zEFUEFUEdXY0KmH0iYzMwY8W4/InWsLiA7AkpAbnexA==",
+      "license": "MIT",
+      "workspaces": [
+        "example"
+      ],
+      "peerDependencies": {
+        "react": "*",
+        "react-native": "*"
       }
     },
     "node_modules/@react-native/assets-registry": {
@@ -5068,6 +5095,15 @@
         "node": ">=0.12.0"
       }
     },
+    "node_modules/is-plain-obj": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/is-plain-obj/-/is-plain-obj-2.1.0.tgz",
+      "integrity": "sha512-YWnfyRwxL/+SsrWYfOpUtz5b3YD+nyfkHvjbcanzk8zgyO4ASD67uVMRt8k5bM4lLMDnXfriRhOpemw+NfT1eA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
     "node_modules/is-wsl": {
       "version": "2.2.0",
       "resolved": "https://registry.npmjs.org/is-wsl/-/is-wsl-2.2.0.tgz",
@@ -5789,6 +5825,18 @@
       "resolved": "https://registry.npmjs.org/memoize-one/-/memoize-one-5.2.1.tgz",
       "integrity": "sha512-zYiwtZUcYyXKo/np96AGZAckk+FWWsUdJ3cHGGmld7+AhvcWmQyGCYUh1hc4Q/pkOhb65dQR/pqCyK0cOaHz4Q==",
       "license": "MIT"
+    },
+    "node_modules/merge-options": {
+      "version": "3.0.4",
+      "resolved": "https://registry.npmjs.org/merge-options/-/merge-options-3.0.4.tgz",
+      "integrity": "sha512-2Sug1+knBjkaMsMgf1ctR1Ujx+Ayku4EdJN4Z+C2+JzoeF7A3OZ9KM2GY0CpQS51NR61LTurMJrRKPhSs3ZRTQ==",
+      "license": "MIT",
+      "dependencies": {
+        "is-plain-obj": "^2.1.0"
+      },
+      "engines": {
+        "node": ">=10"
+      }
     },
     "node_modules/merge-stream": {
       "version": "2.0.0",

--- a/package.json
+++ b/package.json
@@ -12,6 +12,8 @@
   "dependencies": {
     "@expo/vector-icons": "14.1.0",
     "@supabase/supabase-js": "2.56.0",
+    "@react-native-async-storage/async-storage": "^1.23.1",
+    "@react-native-picker/picker": "^2.7.5",
     "expo": "53.0.22",
     "expo-image-picker": "16.1.4",
     "expo-router": "5.1.5",


### PR DESCRIPTION
## Summary
- add Settings tab with radius, goal, and notification options
- store user preferences in AsyncStorage
- include save and reset actions and add required dependencies

## Testing
- `npm test` *(fails: Missing script "test")*


------
https://chatgpt.com/codex/tasks/task_e_68b46ea9dd6c8327a3f2aee7adf4f402