### PR TITLE
feat: add chat and profile controls

### DIFF
--- a/app/(tabs)/profile.tsx
+++ b/app/(tabs)/profile.tsx
@@ -101,6 +101,16 @@ export default function Profile() {
     setPhotoUrl(publicUrl);
   };
 
+  const deletePhoto = async () => {
+    if (!session?.user || !photoUrl) return;
+    const path = photoUrl.split('/profile-photos/')[1];
+    if (path) {
+      await supabase.storage.from('profile-photos').remove([path]);
+    }
+    await supabase.from('photos').delete().eq('user_id', session.user.id);
+    setPhotoUrl(null);
+  };
+
   return (
     <View
       style={[
@@ -116,6 +126,9 @@ export default function Profile() {
         />
       )}
       <Button title="Upload photo" onPress={pickImage} />
+      {photoUrl && (
+        <Button title="Удалить фото" color="#ff6b6b" onPress={deletePhoto} />
+      )}
       <TextInput
         placeholder="Имя"
         value={name}
@@ -145,6 +158,7 @@ export default function Profile() {
           Alert.alert('Success', 'Профиль сохранён');
         }
       }} />
+      <Button title="Выйти из профиля" color="#ff6b6b" onPress={() => supabase.auth.signOut()} />
     </View>
   );
 }

--- a/app/chat/[id].tsx
+++ b/app/chat/[id].tsx
@@ -1,6 +1,6 @@
 import { useEffect, useState } from 'react';
 import { View, Text, FlatList, TextInput, Pressable } from 'react-native';
-import { useLocalSearchParams } from 'expo-router';
+import { useLocalSearchParams, useRouter } from 'expo-router';
 import supabase from '../../lib/supabase';
 import { useAuth } from '../../lib/auth';
 import { aiIcebreaker } from '../../lib/api';
@@ -11,6 +11,7 @@ const demoMode = process.env.EXPO_PUBLIC_DEMO_MODE === 'true';
 export default function Chat() {
   const { id } = useLocalSearchParams();
   const matchId = Array.isArray(id) ? id[0] : id;
+  const router = useRouter();
   const { session } = useAuth();
   const [messages, setMessages] = useState<Message[]>([]);
   const [text, setText] = useState('');
@@ -63,6 +64,21 @@ export default function Chat() {
     setText('');
   };
 
+  const deleteChat = async () => {
+    if (!matchId) return;
+    if (demoMode) {
+      setMessages([]);
+      router.back();
+      return;
+    }
+    await supabase.from('messages').delete().eq('match_id', matchId);
+    router.back();
+  };
+
+  const exitChat = () => {
+    router.back();
+  };
+
   useEffect(() => {
     if (!matchId) return;
     aiIcebreaker(matchId).then(setIcebreaker).catch(console.error);
@@ -70,6 +86,30 @@ export default function Chat() {
 
   return (
     <View style={{ flex: 1, padding: 16 }}>
+      <View style={{ flexDirection: 'row', gap: 8, marginBottom: 16 }}>
+        <Pressable
+          onPress={deleteChat}
+          style={{
+            flex: 1,
+            padding: 12,
+            borderRadius: 12,
+            backgroundColor: '#ff6b6b',
+          }}
+        >
+          <Text style={{ textAlign: 'center' }}>Удалить сообщение</Text>
+        </Pressable>
+        <Pressable
+          onPress={exitChat}
+          style={{
+            flex: 1,
+            padding: 12,
+            borderRadius: 12,
+            backgroundColor: '#5dbea3',
+          }}
+        >
+          <Text style={{ textAlign: 'center' }}>Выход из чата</Text>
+        </Pressable>
+      </View>
       <FlatList
         data={
           icebreaker


### PR DESCRIPTION
## Summary
- add chat buttons to delete conversation and exit
- allow profile photo removal and user sign out

## Testing
- `npm test` *(fails: Missing script "test")*

------
https://chatgpt.com/codex/tasks/task_e_68b46f4a4cd08327813c0c51e7a4bb47