### PR TITLE
Add map chat screen with Google Maps configuration

### DIFF
--- a/android/app/src/main/AndroidManifest.xml
+++ b/android/app/src/main/AndroidManifest.xml
@@ -1,0 +1,9 @@
+<?xml version="1.0" encoding="utf-8"?>
+<manifest xmlns:android="http://schemas.android.com/apk/res/android"
+    package="com.example.aidatingmediator">
+    <application>
+        <meta-data
+            android:name="com.google.android.geo.API_KEY"
+            android:value="YOUR_GOOGLE_MAPS_API_KEY" />
+    </application>
+</manifest>

--- a/app.json
+++ b/app.json
@@ -4,7 +4,19 @@
     "slug": "ai-dating-mediator",
     "scheme": "datingapp",
     "plugins": ["expo-router"],
-    "android": { "package": "com.example.aidatingmediator" },
-    "ios": { "bundleIdentifier": "com.example.aidatingmediator" }
+    "android": {
+      "package": "com.example.aidatingmediator",
+      "config": {
+        "googleMaps": {
+          "apiKey": "YOUR_GOOGLE_MAPS_API_KEY"
+        }
+      }
+    },
+    "ios": {
+      "bundleIdentifier": "com.example.aidatingmediator",
+      "config": {
+        "googleMapsApiKey": "YOUR_GOOGLE_MAPS_API_KEY"
+      }
+    }
   }
 }

--- a/app/(tabs)/mapChat.tsx
+++ b/app/(tabs)/mapChat.tsx
@@ -1,0 +1,37 @@
+import ChatSection from '@/components/ChatSection';
+import mapAgent from '@/lib/mapAgent';
+import MapView, { Marker } from 'react-native-maps';
+import { sampleProfiles } from '../../lib/sample-data';
+
+function MapExtra() {
+  const first = sampleProfiles[0]?.coordinates ?? { lat: 0, lng: 0 };
+  const initialRegion = {
+    latitude: first.lat,
+    longitude: first.lng,
+    latitudeDelta: 5,
+    longitudeDelta: 5,
+  };
+
+  return (
+    <MapView style={{ width: '100%', height: 200 }} initialRegion={initialRegion}>
+      {sampleProfiles.map((p) =>
+        p.coordinates ? (
+          <Marker
+            key={p.id}
+            coordinate={{
+              latitude: p.coordinates.lat,
+              longitude: p.coordinates.lng,
+            }}
+            title={p.name}
+            description={p.bio}
+          />
+        ) : null
+      )}
+    </MapView>
+  );
+}
+
+export default function MapChat() {
+  return <ChatSection section="map" agent={mapAgent} extra={<MapExtra />} />;
+}
+

--- a/ios/Info.plist
+++ b/ios/Info.plist
@@ -1,0 +1,8 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+  <key>GMSApiKey</key>
+  <string>YOUR_GOOGLE_MAPS_API_KEY</string>
+</dict>
+</plist>


### PR DESCRIPTION
## Summary
- add map chat screen rendering sample profile markers
- configure Google Maps API key across platforms

## Testing
- `npm test` *(fails: Missing script "test")*

------
https://chatgpt.com/codex/tasks/task_e_68b4b0dbbc1c8327b0c34b40fd647b69