### PR TITLE
Add settings chat with notifications toggle

### DIFF
--- a/app/(tabs)/settingsChat.tsx
+++ b/app/(tabs)/settingsChat.tsx
@@ -1,0 +1,29 @@
+import { useState } from 'react';
+import { View, Text, Switch } from 'react-native';
+import ChatSection from '@/components/ChatSection';
+import settingsAgent from '@/lib/settingsAgent';
+
+export default function SettingsChat() {
+  const [notifications, setNotifications] = useState(true);
+
+  const agent = async (msg: string) => {
+    const res = await settingsAgent(msg, { notifications });
+    if (typeof res.state?.notifications === 'boolean') {
+      setNotifications(res.state.notifications);
+    }
+    return res;
+  };
+
+  return (
+    <ChatSection
+      section="settings"
+      agent={agent}
+      extra={
+        <View style={{ flexDirection: 'row', alignItems: 'center', padding: 8 }}>
+          <Text style={{ marginRight: 8 }}>Notifications</Text>
+          <Switch value={notifications} onValueChange={setNotifications} />
+        </View>
+      }
+    />
+  );
+}

--- a/lib/settingsAgent.ts
+++ b/lib/settingsAgent.ts
@@ -1,0 +1,20 @@
+import { AgentResponse } from './localAgents';
+
+export default async function settingsAgent(
+  msg: string,
+  state: { notifications: boolean } = { notifications: true }
+): Promise<AgentResponse<typeof state>> {
+  const lower = msg.toLowerCase();
+  if (lower.includes('off') || lower.includes('disable') || lower.includes('выкл')) {
+    state.notifications = false;
+    return { reply: 'Notifications disabled.', state };
+  }
+  if (lower.includes('on') || lower.includes('enable') || lower.includes('вкл')) {
+    state.notifications = true;
+    return { reply: 'Notifications enabled.', state };
+  }
+  return {
+    reply: `Notifications are ${state.notifications ? 'on' : 'off'}.`,
+    state,
+  };
+}


### PR DESCRIPTION
## Summary
- Add `settingsChat` screen with local `notifications` state and UI switch
- Introduce `settingsAgent` and wrap it to keep notifications state in sync

## Testing
- `npm test` *(fails: Missing script: "test")*

------
https://chatgpt.com/codex/tasks/task_e_68b4b1a9e6448327a25eea992ea0e05e