### PR TITLE
feat: add chat tab routes

### DIFF
--- a/app/(tabs)/_layout.tsx
+++ b/app/(tabs)/_layout.tsx
@@ -66,6 +66,34 @@ export default function TabsLayout() {
           ),
         }}
       />
+      <Tabs.Screen
+        name="profileChat"
+        options={{
+          title: 'Profile Chat',
+          href: null,
+        }}
+      />
+      <Tabs.Screen
+        name="searchChat"
+        options={{
+          title: 'Search Chat',
+          href: null,
+        }}
+      />
+      <Tabs.Screen
+        name="mapChat"
+        options={{
+          title: 'Map Chat',
+          href: null,
+        }}
+      />
+      <Tabs.Screen
+        name="settingsChat"
+        options={{
+          title: 'Settings Chat',
+          href: null,
+        }}
+      />
     </Tabs>
   );
 }


### PR DESCRIPTION
## Summary
- expose chat screens for profile, search, map and settings in the tabs layout

## Testing
- `npm test` *(fails: Missing script "test")*

------
https://chatgpt.com/codex/tasks/task_e_68b4b278a1d083279f2e777c69d53a3a