### PR TITLE
refactor: use theme colors

### DIFF
--- a/app/chat/[id].tsx
+++ b/app/chat/[id].tsx
@@ -5,6 +5,8 @@ import supabase from '../../lib/supabase';
 import { useAuth } from '../../lib/auth';
 import { aiIcebreaker } from '../../lib/api';
 import { sampleMessages, Message } from '../../lib/sample-messages';
+import Colors from '@/constants/Colors';
+import { useColorScheme } from '@/components/useColorScheme';
 
 const demoMode = process.env.EXPO_PUBLIC_DEMO_MODE === 'true';
 
@@ -16,6 +18,7 @@ export default function Chat() {
   const [messages, setMessages] = useState<Message[]>([]);
   const [text, setText] = useState('');
   const [icebreaker, setIcebreaker] = useState<string | null>(null);
+  const colorScheme = useColorScheme() ?? 'light';
 
   useEffect(() => {
     if (!matchId) return;
@@ -93,7 +96,7 @@ export default function Chat() {
             flex: 1,
             padding: 12,
             borderRadius: 12,
-            backgroundColor: '#ff6b6b',
+            backgroundColor: Colors[colorScheme].danger,
           }}
         >
           <Text style={{ textAlign: 'center' }}>Удалить сообщение</Text>
@@ -104,7 +107,7 @@ export default function Chat() {
             flex: 1,
             padding: 12,
             borderRadius: 12,
-            backgroundColor: '#5dbea3',
+            backgroundColor: Colors[colorScheme].primary,
           }}
         >
           <Text style={{ textAlign: 'center' }}>Выход из чата</Text>
@@ -129,7 +132,7 @@ export default function Chat() {
         renderItem={({ item }) => (
           <View style={{ marginBottom: 8 }}>
             {item.id === 'ai-icebreaker' ? (
-              <Text style={{ fontStyle: 'italic', color: '#888' }}>
+              <Text style={{ fontStyle: 'italic', color: Colors[colorScheme].muted }}>
                 Пример: {item.content}
               </Text>
             ) : (
@@ -140,14 +143,19 @@ export default function Chat() {
       />
       <View style={{ flexDirection: 'row', gap: 8, marginTop: 16 }}>
         <TextInput
-          style={{ flex: 1, backgroundColor: '#111', padding: 12, borderRadius: 12 }}
+          style={{
+            flex: 1,
+            backgroundColor: Colors[colorScheme].inputBackground,
+            padding: 12,
+            borderRadius: 12,
+          }}
           value={text}
           onChangeText={setText}
           placeholder="Сообщение"
         />
         <Pressable
           onPress={send}
-          style={{ padding: 12, borderRadius: 12, backgroundColor: '#5dbea3' }}
+          style={{ padding: 12, borderRadius: 12, backgroundColor: Colors[colorScheme].primary }}
         >
           <Text>Отправить</Text>
         </Pressable>

--- a/components/Sidebar.tsx
+++ b/components/Sidebar.tsx
@@ -1,5 +1,7 @@
 import { View, Text, Pressable, StyleSheet } from 'react-native';
 import { Link, usePathname } from 'expo-router';
+import Colors from '@/constants/Colors';
+import { useColorScheme } from './useColorScheme';
 
 const items = [
   { href: '/', label: 'Discover' },
@@ -10,15 +12,20 @@ const items = [
 
 export default function Sidebar() {
   const pathname = usePathname();
+  const colorScheme = useColorScheme() ?? 'light';
 
   return (
-    <View style={styles.container}>
+    <View style={[styles.container, { backgroundColor: Colors[colorScheme].sidebar }]}>
       {items.map((item) => {
         const active = pathname === item.href;
         return (
           <Link key={item.href} href={item.href} asChild>
-            <Pressable style={[styles.item, active && styles.activeItem]}>
-              <Text style={styles.itemText}>{item.label}</Text>
+            <Pressable
+              style={[styles.item, active && { backgroundColor: Colors[colorScheme].sidebarActive }]}
+            >
+              <Text style={[styles.itemText, { color: Colors[colorScheme].text }]}>
+                {item.label}
+              </Text>
             </Pressable>
           </Link>
         );
@@ -30,18 +37,13 @@ export default function Sidebar() {
 const styles = StyleSheet.create({
   container: {
     width: 280,
-    backgroundColor: '#202123',
     paddingTop: 24,
   },
   item: {
     paddingVertical: 12,
     paddingHorizontal: 16,
   },
-  activeItem: {
-    backgroundColor: '#343541',
-  },
   itemText: {
-    color: '#fff',
     fontSize: 16,
   },
 });

--- a/components/ui/Button.tsx
+++ b/components/ui/Button.tsx
@@ -1,14 +1,23 @@
 import { Pressable, Text, ViewStyle, useWindowDimensions } from 'react-native';
+import Colors from '@/constants/Colors';
+import { useColorScheme } from '../useColorScheme';
 
 export default function Button({ title, onPress, style }: { title: string; onPress?: () => void; style?: ViewStyle }) {
   const { width } = useWindowDimensions();
   const isDesktop = width >= 768;
+  const colorScheme = useColorScheme() ?? 'light';
 
   return (
     <Pressable
       onPress={onPress}
       style={[
-        { padding: 12, borderRadius: 12, backgroundColor: '#5dbea3', alignItems: 'center', alignSelf: 'flex-start' },
+        {
+          padding: 12,
+          borderRadius: 12,
+          backgroundColor: Colors[colorScheme].primary,
+          alignItems: 'center',
+          alignSelf: 'flex-start',
+        },
         isDesktop && { alignSelf: 'center', width: '100%', maxWidth: 200 },
         style,
       ]}

--- a/constants/Colors.ts
+++ b/constants/Colors.ts
@@ -1,5 +1,14 @@
 const tintColorLight = '#FFC0CB';
 const tintColorDark = '#FFB6C1';
+const dangerColorLight = '#FF8FA3';
+const dangerColorDark = '#FF748C';
+const sidebarLight = '#F2F2F7';
+const sidebarDark = '#202123';
+const sidebarActiveLight = '#E5E5EA';
+const sidebarActiveDark = '#343541';
+const inputBackgroundLight = '#F0F0F0';
+const inputBackgroundDark = '#111';
+const mutedColor = '#888';
 
 export default {
   light: {
@@ -8,6 +17,12 @@ export default {
     tint: tintColorLight,
     tabIconDefault: '#ccc',
     tabIconSelected: tintColorLight,
+    primary: tintColorLight,
+    danger: dangerColorLight,
+    muted: mutedColor,
+    sidebar: sidebarLight,
+    sidebarActive: sidebarActiveLight,
+    inputBackground: inputBackgroundLight,
   },
   dark: {
     text: '#fff',
@@ -15,5 +30,11 @@ export default {
     tint: tintColorDark,
     tabIconDefault: '#ccc',
     tabIconSelected: tintColorDark,
+    primary: tintColorDark,
+    danger: dangerColorDark,
+    muted: mutedColor,
+    sidebar: sidebarDark,
+    sidebarActive: sidebarActiveDark,
+    inputBackground: inputBackgroundDark,
   },
 };


### PR DESCRIPTION
## Summary
- replace hardcoded hex codes in sidebar, chat and button components with theme constants
- expand Colors theme with pastel pink palette entries like primary, danger, sidebar and muted shades

## Testing
- `npm test` *(fails: Missing script "test")*

------
https://chatgpt.com/codex/tasks/task_e_68b4c35e3ba083279bbaad2d876a35c1