### PR TITLE
feat: add pastel sidebar colors

### DIFF
--- a/components/Sidebar.tsx
+++ b/components/Sidebar.tsx
@@ -15,7 +15,7 @@ export default function Sidebar() {
   const colorScheme = useColorScheme() ?? 'light';
 
   return (
-    <View style={[styles.container, { backgroundColor: Colors[colorScheme].sidebar }]}>
+    <View style={[styles.container, { backgroundColor: Colors[colorScheme].sidebarBackground }]}> 
       {items.map((item) => {
         const active = pathname === item.href;
         return (

--- a/constants/Colors.ts
+++ b/constants/Colors.ts
@@ -2,10 +2,10 @@ const tintColorLight = '#FFC0CB';
 const tintColorDark = '#FFB6C1';
 const dangerColorLight = '#FF8FA3';
 const dangerColorDark = '#FF748C';
-const sidebarLight = '#F2F2F7';
-const sidebarDark = '#202123';
-const sidebarActiveLight = '#E5E5EA';
-const sidebarActiveDark = '#343541';
+const sidebarBackgroundLight = '#FFF5F7';
+const sidebarBackgroundDark = '#2B1C23';
+const sidebarActiveLight = tintColorLight;
+const sidebarActiveDark = tintColorDark;
 const inputBackgroundLight = '#F0F0F0';
 const inputBackgroundDark = '#111';
 const mutedColor = '#888';
@@ -20,7 +20,7 @@ export default {
     primary: tintColorLight,
     danger: dangerColorLight,
     muted: mutedColor,
-    sidebar: sidebarLight,
+    sidebarBackground: sidebarBackgroundLight,
     sidebarActive: sidebarActiveLight,
     inputBackground: inputBackgroundLight,
   },
@@ -33,7 +33,7 @@ export default {
     primary: tintColorDark,
     danger: dangerColorDark,
     muted: mutedColor,
-    sidebar: sidebarDark,
+    sidebarBackground: sidebarBackgroundDark,
     sidebarActive: sidebarActiveDark,
     inputBackground: inputBackgroundDark,
   },


### PR DESCRIPTION
## Summary
- use pastel pink background for sidebar
- highlight active sidebar item with theme accent

## Testing
- `npm test` *(fails: Missing script "test")*

------
https://chatgpt.com/codex/tasks/task_e_68b4c4dea63c8327983be5a3176fc168