### PR TITLE
Apply soft pink styling for chat and buttons

### DIFF
--- a/app/chat/[id].tsx
+++ b/app/chat/[id].tsx
@@ -99,7 +99,9 @@ export default function Chat() {
             backgroundColor: Colors[colorScheme].danger,
           }}
         >
-          <Text style={{ textAlign: 'center' }}>Удалить сообщение</Text>
+          <Text style={{ textAlign: 'center', color: Colors[colorScheme].text }}>
+            Удалить сообщение
+          </Text>
         </Pressable>
         <Pressable
           onPress={exitChat}
@@ -110,7 +112,9 @@ export default function Chat() {
             backgroundColor: Colors[colorScheme].primary,
           }}
         >
-          <Text style={{ textAlign: 'center' }}>Выход из чата</Text>
+          <Text style={{ textAlign: 'center', color: Colors[colorScheme].text }}>
+            Выход из чата
+          </Text>
         </Pressable>
       </View>
       <FlatList
@@ -152,12 +156,13 @@ export default function Chat() {
           value={text}
           onChangeText={setText}
           placeholder="Сообщение"
+          placeholderTextColor={Colors[colorScheme].muted}
         />
         <Pressable
           onPress={send}
           style={{ padding: 12, borderRadius: 12, backgroundColor: Colors[colorScheme].primary }}
         >
-          <Text>Отправить</Text>
+          <Text style={{ color: Colors[colorScheme].text }}>Отправить</Text>
         </Pressable>
       </View>
     </View>

--- a/components/ui/Button.tsx
+++ b/components/ui/Button.tsx
@@ -10,19 +10,20 @@ export default function Button({ title, onPress, style }: { title: string; onPre
   return (
     <Pressable
       onPress={onPress}
-      style={[
+      style={({ pressed }) => [
         {
           padding: 12,
           borderRadius: 12,
           backgroundColor: Colors[colorScheme].primary,
           alignItems: 'center',
           alignSelf: 'flex-start',
+          opacity: pressed ? 0.8 : 1,
         },
         isDesktop && { alignSelf: 'center', width: '100%', maxWidth: 200 },
         style,
       ]}
     >
-      <Text style={{ fontWeight: '600' }}>{title}</Text>
+      <Text style={{ fontWeight: '600', color: Colors[colorScheme].text }}>{title}</Text>
     </Pressable>
   );
 }

--- a/constants/Colors.ts
+++ b/constants/Colors.ts
@@ -1,13 +1,13 @@
-const tintColorLight = '#FFC0CB';
-const tintColorDark = '#FFB6C1';
-const dangerColorLight = '#FF8FA3';
-const dangerColorDark = '#FF748C';
+const tintColorLight = '#FFB3C6';
+const tintColorDark = '#FF8DAA';
+const dangerColorLight = '#FF9AA2';
+const dangerColorDark = '#FF8090';
 const sidebarBackgroundLight = '#FFF5F7';
 const sidebarBackgroundDark = '#2B1C23';
 const sidebarActiveLight = tintColorLight;
 const sidebarActiveDark = tintColorDark;
-const inputBackgroundLight = '#F0F0F0';
-const inputBackgroundDark = '#111';
+const inputBackgroundLight = '#FDE4EC';
+const inputBackgroundDark = '#4A2C3A';
 const mutedColor = '#888';
 
 export default {


### PR DESCRIPTION
## Summary
- replace chat colors with soft pinks and ensure text contrast
- use pink background button component with pressed feedback
- update color constants for light and dark themes

## Testing
- `npm test` *(fails: Missing script "test")*

------
https://chatgpt.com/codex/tasks/task_e_68b4c5b80b888327a9810bec28966a69