### PR TITLE
refactor: use theme colors

### DIFF
--- a/app/(auth)/onboarding.tsx
+++ b/app/(auth)/onboarding.tsx
@@ -1,14 +1,19 @@
 import { View, Text, Pressable } from 'react-native';
 import { Link } from 'expo-router';
+import Colors from '@/constants/Colors';
+import { useColorScheme } from '@/components/useColorScheme';
 
 export default function Onboarding() {
+  const colorScheme = useColorScheme() ?? 'light';
   return (
     <View style={{ flex: 1, padding: 16, justifyContent: 'center', gap: 16 }}>
       <Text style={{ fontSize: 28, fontWeight: '700' }}>AI Dating Mediator</Text>
       <Text style={{ opacity: 0.7 }}>Короткий онбординг и загрузка фото — далее лента кандидатов и ИИ‑медиатор в чате.</Text>
       <Link href="/(auth)/sign-in" asChild>
-        <Pressable style={{ padding: 12, borderRadius: 12, backgroundColor: '#5dbea3' }}>
-          <Text>Продолжить</Text>
+        <Pressable
+          style={{ padding: 12, borderRadius: 12, backgroundColor: Colors[colorScheme].primary }}
+        >
+          <Text style={{ color: Colors[colorScheme].text }}>Продолжить</Text>
         </Pressable>
       </Link>
     </View>

--- a/app/(auth)/sign-in.tsx
+++ b/app/(auth)/sign-in.tsx
@@ -2,9 +2,12 @@ import { useState } from 'react';
 import { View, Text, TextInput, Pressable, Alert } from 'react-native';
 import * as Linking from 'expo-linking';
 import supabase from '../../lib/supabase';
+import Colors from '@/constants/Colors';
+import { useColorScheme } from '@/components/useColorScheme';
 
 export default function SignIn() {
   const [email, setEmail] = useState('');
+  const colorScheme = useColorScheme() ?? 'light';
 
   return (
     <View style={{ flex: 1, padding: 16, justifyContent: 'center', gap: 12 }}>
@@ -15,7 +18,7 @@ export default function SignIn() {
         autoCapitalize="none"
         value={email}
         onChangeText={setEmail}
-        style={{ backgroundColor: '#111', padding: 12, borderRadius: 12 }}
+        style={{ backgroundColor: Colors[colorScheme].inputBackground, padding: 12, borderRadius: 12 }}
       />
       <Pressable
         onPress={async () => {
@@ -30,9 +33,9 @@ export default function SignIn() {
             Alert.alert('Проверьте почту', 'Мы отправили вам ссылку для входа.');
           }
         }}
-        style={{ padding: 12, borderRadius: 12, backgroundColor: '#5dbea3' }}
+        style={{ padding: 12, borderRadius: 12, backgroundColor: Colors[colorScheme].primary }}
       >
-        <Text>Отправить код</Text>
+        <Text style={{ color: Colors[colorScheme].text }}>Отправить код</Text>
       </Pressable>
     </View>
   );

--- a/app/(tabs)/index.tsx
+++ b/app/(tabs)/index.tsx
@@ -1,5 +1,7 @@
 import { View, Text, Pressable, Image, useWindowDimensions } from 'react-native';
 import { useState, useEffect } from 'react';
+import Colors from '@/constants/Colors';
+import { useColorScheme } from '@/components/useColorScheme';
 import { useRouter } from 'expo-router';
 import supabase from '../../lib/supabase';
 import { fetchCandidates } from '../../lib/api';
@@ -12,6 +14,7 @@ export default function Discover() {
   const router = useRouter();
   const { width } = useWindowDimensions();
   const isDesktop = width >= 768;
+  const colorScheme = useColorScheme() ?? 'light';
 
   useEffect(() => {
     fetchCandidates().then(setCandidates).catch(() => setCandidates([]));
@@ -58,13 +61,18 @@ export default function Discover() {
       <View style={{ flexDirection: 'row', justifyContent: 'space-between', alignItems: 'center' }}>
         <Text style={{ fontSize: 24, fontWeight: '600' }}>Discover</Text>
         <Pressable onPress={() => router.push('/(tabs)/map')}>
-          <Text style={{ color: '#5dbea3' }}>Map</Text>
+          <Text style={{ color: Colors[colorScheme].primary }}>Map</Text>
         </Pressable>
       </View>
       {c ? (
         <View
           style={[
-            { padding: 16, borderRadius: 16, backgroundColor: '#222', width: '100%' },
+            {
+              padding: 16,
+              borderRadius: 16,
+              backgroundColor: Colors[colorScheme].inputBackground,
+              width: '100%',
+            },
             isDesktop && { maxWidth: 600, alignSelf: 'center' },
           ]}
         >
@@ -81,7 +89,7 @@ export default function Discover() {
                 height: 300,
                 borderRadius: 16,
                 marginBottom: 8,
-                backgroundColor: '#333',
+                backgroundColor: Colors[colorScheme].inputBackground,
                 justifyContent: 'center',
                 alignItems: 'center',
               }}
@@ -103,15 +111,15 @@ export default function Discover() {
       <View style={{ flexDirection: 'row', gap: 12 }}>
         <Pressable
           onPress={() => setI((x) => Math.min(x + 1, candidates.length))}
-          style={{ padding: 12, backgroundColor: '#444', borderRadius: 12 }}
+          style={{ padding: 12, backgroundColor: Colors[colorScheme].inputBackground, borderRadius: 12 }}
         >
-          <Text>Skip</Text>
+          <Text style={{ color: Colors[colorScheme].text }}>Skip</Text>
         </Pressable>
         <Pressable
           onPress={handleLike}
-          style={{ padding: 12, backgroundColor: '#5dbea3', borderRadius: 12 }}
+          style={{ padding: 12, backgroundColor: Colors[colorScheme].primary, borderRadius: 12 }}
         >
-          <Text>Like</Text>
+          <Text style={{ color: Colors[colorScheme].text }}>Like</Text>
         </Pressable>
       </View>
       {showMatch && (
@@ -121,7 +129,7 @@ export default function Discover() {
             top: 0,
             left: 0,
             right: 0,
-            backgroundColor: '#5dbea3',
+            backgroundColor: Colors[colorScheme].primary,
             padding: 12,
             alignItems: 'center',
           }}

--- a/app/(tabs)/profile.tsx
+++ b/app/(tabs)/profile.tsx
@@ -4,6 +4,8 @@ import * as ImagePicker from 'expo-image-picker';
 import supabase from '../../lib/supabase';
 import { useAuth } from '../../lib/auth';
 import { sampleProfiles } from '../../lib/sample-data';
+import Colors from '@/constants/Colors';
+import { useColorScheme } from '@/components/useColorScheme';
 
 export default function Profile() {
   const { session } = useAuth();
@@ -12,6 +14,7 @@ export default function Profile() {
   const [bio, setBio] = useState('');
   const { width } = useWindowDimensions();
   const isDesktop = width >= 768;
+  const colorScheme = useColorScheme() ?? 'light';
 
   useEffect(() => {
     if (!session?.user) return;
@@ -127,20 +130,20 @@ export default function Profile() {
       )}
       <Button title="Upload photo" onPress={pickImage} />
       {photoUrl && (
-        <Button title="Удалить фото" color="#ff6b6b" onPress={deletePhoto} />
+        <Button title="Удалить фото" color={Colors[colorScheme].danger} onPress={deletePhoto} />
       )}
       <TextInput
         placeholder="Имя"
         value={name}
         onChangeText={setName}
-        style={{ backgroundColor: '#111', padding: 12, borderRadius: 12 }}
+        style={{ backgroundColor: Colors[colorScheme].inputBackground, padding: 12, borderRadius: 12 }}
       />
       <TextInput
         placeholder="О себе"
         value={bio}
         onChangeText={setBio}
         multiline
-        style={{ backgroundColor: '#111', padding: 12, borderRadius: 12, minHeight: 100 }}
+        style={{ backgroundColor: Colors[colorScheme].inputBackground, padding: 12, borderRadius: 12, minHeight: 100 }}
       />
       <Button title="Сохранить" onPress={async () => {
         if (!session?.user) return;
@@ -158,7 +161,7 @@ export default function Profile() {
           Alert.alert('Success', 'Профиль сохранён');
         }
       }} />
-      <Button title="Выйти из профиля" color="#ff6b6b" onPress={() => supabase.auth.signOut()} />
+      <Button title="Выйти из профиля" color={Colors[colorScheme].danger} onPress={() => supabase.auth.signOut()} />
     </View>
   );
 }

--- a/app/(tabs)/settings.tsx
+++ b/app/(tabs)/settings.tsx
@@ -2,10 +2,13 @@ import { useEffect, useState } from 'react';
 import { View, Text, Switch, Button, useWindowDimensions } from 'react-native';
 import { Picker } from '@react-native-picker/picker';
 import { loadPreferences, savePreferences, resetPreferences, Preferences } from '../../lib/preferences';
+import Colors from '@/constants/Colors';
+import { useColorScheme } from '@/components/useColorScheme';
 
 export default function Settings() {
   const { width } = useWindowDimensions();
   const isDesktop = width >= 768;
+  const colorScheme = useColorScheme() ?? 'light';
 
   const [prefs, setPrefs] = useState<Preferences>({
     radius: 10,
@@ -30,7 +33,7 @@ export default function Settings() {
       <Picker
         selectedValue={prefs.radius}
         onValueChange={(value) => setPrefs({ ...prefs, radius: value })}
-        style={{ backgroundColor: '#111', borderRadius: 12 }}
+        style={{ backgroundColor: Colors[colorScheme].inputBackground, borderRadius: 12 }}
       >
         <Picker.Item label="5 km" value={5} />
         <Picker.Item label="10 km" value={10} />
@@ -42,7 +45,7 @@ export default function Settings() {
       <Picker
         selectedValue={prefs.goal}
         onValueChange={(value) => setPrefs({ ...prefs, goal: value })}
-        style={{ backgroundColor: '#111', borderRadius: 12 }}
+        style={{ backgroundColor: Colors[colorScheme].inputBackground, borderRadius: 12 }}
       >
         <Picker.Item label="Serious relationship" value="serious" />
         <Picker.Item label="Casual dating" value="casual" />

--- a/components/ChatSection.tsx
+++ b/components/ChatSection.tsx
@@ -1,5 +1,7 @@
 import React from 'react';
 import { FlatList, TextInput, Pressable, View, Text, StyleSheet } from 'react-native';
+import Colors from '@/constants/Colors';
+import { useColorScheme } from './useColorScheme';
 
 interface Message {
   id: string;
@@ -18,6 +20,7 @@ interface ChatSectionProps {
 }
 
 export default function ChatSection({ state, setState, extra }: ChatSectionProps) {
+  const colorScheme = useColorScheme() ?? 'light';
   const handleSend = () => {
     const trimmed = state.input.trim();
     if (!trimmed) return;
@@ -40,13 +43,16 @@ export default function ChatSection({ state, setState, extra }: ChatSectionProps
       {extra}
       <View style={styles.inputRow}>
         <TextInput
-          style={styles.input}
+          style={[styles.input, { borderColor: Colors[colorScheme].muted }]}
           value={state.input}
           onChangeText={(text) => setState((prev) => ({ ...prev, input: text }))}
           placeholder="Type a message"
         />
-        <Pressable style={styles.button} onPress={handleSend}>
-          <Text style={styles.buttonText}>Send</Text>
+        <Pressable
+          style={[styles.button, { backgroundColor: Colors[colorScheme].primary }]}
+          onPress={handleSend}
+        >
+          <Text style={[styles.buttonText, { color: Colors[colorScheme].text }]}>Send</Text>
         </Pressable>
       </View>
     </View>
@@ -72,7 +78,6 @@ const styles = StyleSheet.create({
   input: {
     flex: 1,
     borderWidth: 1,
-    borderColor: '#ccc',
     borderRadius: 4,
     paddingHorizontal: 8,
     paddingVertical: 4,
@@ -81,11 +86,9 @@ const styles = StyleSheet.create({
   button: {
     paddingHorizontal: 12,
     paddingVertical: 8,
-    backgroundColor: '#007bff',
     borderRadius: 4,
   },
   buttonText: {
-    color: '#fff',
     fontWeight: 'bold',
   },
 });

--- a/components/ui/Card.tsx
+++ b/components/ui/Card.tsx
@@ -1,13 +1,21 @@
 import { View, ViewStyle, useWindowDimensions } from 'react-native';
+import Colors from '@/constants/Colors';
+import { useColorScheme } from '../useColorScheme';
 
 export default function Card({ children, style }: { children: React.ReactNode; style?: ViewStyle }) {
   const { width } = useWindowDimensions();
   const isDesktop = width >= 768;
+  const colorScheme = useColorScheme() ?? 'light';
 
   return (
     <View
       style={[
-        { padding: 16, borderRadius: 16, backgroundColor: '#222', width: '100%' },
+        {
+          padding: 16,
+          borderRadius: 16,
+          backgroundColor: Colors[colorScheme].inputBackground,
+          width: '100%',
+        },
         isDesktop && { maxWidth: 600, alignSelf: 'center' },
         style,
       ]}


### PR DESCRIPTION
## Summary
- replace hardcoded background colors with theme variables
- use `useColorScheme` and `Colors` across auth and tab screens
- update shared components to respect light and dark themes

## Testing
- `npm test` *(fails: Missing script "test")*

------
https://chatgpt.com/codex/tasks/task_e_68b4c91883788327ab32dfbbe50ad675