### PR TITLE
Use themed components in screens and UI

### DIFF
--- a/app/(auth)/onboarding.tsx
+++ b/app/(auth)/onboarding.tsx
@@ -1,7 +1,8 @@
-import { View, Text, Pressable } from 'react-native';
+import { Pressable } from 'react-native';
 import { Link } from 'expo-router';
 import Colors from '@/constants/Colors';
 import { useColorScheme } from '@/components/useColorScheme';
+import { Text, View } from '@/components/Themed';
 
 export default function Onboarding() {
   const colorScheme = useColorScheme() ?? 'light';
@@ -13,7 +14,7 @@ export default function Onboarding() {
         <Pressable
           style={{ padding: 12, borderRadius: 12, backgroundColor: Colors[colorScheme].primary }}
         >
-          <Text style={{ color: Colors[colorScheme].text }}>Продолжить</Text>
+          <Text>Продолжить</Text>
         </Pressable>
       </Link>
     </View>

--- a/app/(auth)/sign-in.tsx
+++ b/app/(auth)/sign-in.tsx
@@ -1,9 +1,10 @@
 import { useState } from 'react';
-import { View, Text, TextInput, Pressable, Alert } from 'react-native';
+import { TextInput, Pressable, Alert } from 'react-native';
 import * as Linking from 'expo-linking';
 import supabase from '../../lib/supabase';
 import Colors from '@/constants/Colors';
 import { useColorScheme } from '@/components/useColorScheme';
+import { Text, View } from '@/components/Themed';
 
 export default function SignIn() {
   const [email, setEmail] = useState('');
@@ -35,7 +36,7 @@ export default function SignIn() {
         }}
         style={{ padding: 12, borderRadius: 12, backgroundColor: Colors[colorScheme].primary }}
       >
-        <Text style={{ color: Colors[colorScheme].text }}>Отправить код</Text>
+        <Text>Отправить код</Text>
       </Pressable>
     </View>
   );

--- a/app/(tabs)/inbox.tsx
+++ b/app/(tabs)/inbox.tsx
@@ -1,4 +1,5 @@
-import { View, Text, useWindowDimensions } from 'react-native';
+import { useWindowDimensions } from 'react-native';
+import { Text, View } from '@/components/Themed';
 
 export default function Inbox() {
   const { width } = useWindowDimensions();

--- a/app/(tabs)/index.tsx
+++ b/app/(tabs)/index.tsx
@@ -1,4 +1,5 @@
-import { View, Text, Pressable, Image, useWindowDimensions } from 'react-native';
+import { Pressable, Image, useWindowDimensions } from 'react-native';
+import { Text, View } from '@/components/Themed';
 import { useState, useEffect } from 'react';
 import Colors from '@/constants/Colors';
 import { useColorScheme } from '@/components/useColorScheme';
@@ -113,13 +114,13 @@ export default function Discover() {
           onPress={() => setI((x) => Math.min(x + 1, candidates.length))}
           style={{ padding: 12, backgroundColor: Colors[colorScheme].inputBackground, borderRadius: 12 }}
         >
-          <Text style={{ color: Colors[colorScheme].text }}>Skip</Text>
+          <Text>Skip</Text>
         </Pressable>
         <Pressable
           onPress={handleLike}
           style={{ padding: 12, backgroundColor: Colors[colorScheme].primary, borderRadius: 12 }}
         >
-          <Text style={{ color: Colors[colorScheme].text }}>Like</Text>
+          <Text>Like</Text>
         </Pressable>
       </View>
       {showMatch && (

--- a/app/(tabs)/map.tsx
+++ b/app/(tabs)/map.tsx
@@ -1,4 +1,5 @@
-import { View, useWindowDimensions } from 'react-native';
+import { useWindowDimensions } from 'react-native';
+import { View } from '@/components/Themed';
 import MapView, { Marker } from 'react-native-maps';
 import { sampleProfiles } from '../../lib/sample-data';
 

--- a/app/(tabs)/matches.tsx
+++ b/app/(tabs)/matches.tsx
@@ -1,4 +1,5 @@
-import { View, Text, useWindowDimensions } from 'react-native';
+import { useWindowDimensions } from 'react-native';
+import { Text, View } from '@/components/Themed';
 
 export default function Matches() {
   const { width } = useWindowDimensions();

--- a/app/(tabs)/profile.tsx
+++ b/app/(tabs)/profile.tsx
@@ -1,11 +1,12 @@
 import { useEffect, useState } from 'react';
-import { View, Text, TextInput, Button, Image, useWindowDimensions, Alert } from 'react-native';
+import { TextInput, Button, Image, useWindowDimensions, Alert } from 'react-native';
 import * as ImagePicker from 'expo-image-picker';
 import supabase from '../../lib/supabase';
 import { useAuth } from '../../lib/auth';
 import { sampleProfiles } from '../../lib/sample-data';
 import Colors from '@/constants/Colors';
 import { useColorScheme } from '@/components/useColorScheme';
+import { Text, View } from '@/components/Themed';
 
 export default function Profile() {
   const { session } = useAuth();

--- a/app/(tabs)/settings.tsx
+++ b/app/(tabs)/settings.tsx
@@ -1,5 +1,6 @@
 import { useEffect, useState } from 'react';
-import { View, Text, Switch, Button, useWindowDimensions } from 'react-native';
+import { Switch, Button, useWindowDimensions } from 'react-native';
+import { Text, View } from '@/components/Themed';
 import { Picker } from '@react-native-picker/picker';
 import { loadPreferences, savePreferences, resetPreferences, Preferences } from '../../lib/preferences';
 import Colors from '@/constants/Colors';

--- a/app/(tabs)/settingsChat.tsx
+++ b/app/(tabs)/settingsChat.tsx
@@ -1,5 +1,6 @@
 import { useState } from 'react';
-import { View, Text, Switch } from 'react-native';
+import { Switch } from 'react-native';
+import { Text, View } from '@/components/Themed';
 import ChatSection from '@/components/ChatSection';
 import settingsAgent from '@/lib/settingsAgent';
 

--- a/app/_layout.tsx
+++ b/app/_layout.tsx
@@ -1,6 +1,7 @@
 import { Stack } from 'expo-router';
 import { AuthProvider } from '../lib/auth';
-import { View, useWindowDimensions } from 'react-native';
+import { useWindowDimensions } from 'react-native';
+import { View } from '@/components/Themed';
 import Sidebar from '../components/Sidebar';
 
 export default function RootLayout() {

--- a/app/chat/[id].tsx
+++ b/app/chat/[id].tsx
@@ -1,5 +1,6 @@
 import { useEffect, useState } from 'react';
-import { View, Text, FlatList, TextInput, Pressable } from 'react-native';
+import { FlatList, TextInput, Pressable } from 'react-native';
+import { Text, View } from '@/components/Themed';
 import { useLocalSearchParams, useRouter } from 'expo-router';
 import supabase from '../../lib/supabase';
 import { useAuth } from '../../lib/auth';
@@ -99,9 +100,7 @@ export default function Chat() {
             backgroundColor: Colors[colorScheme].danger,
           }}
         >
-          <Text style={{ textAlign: 'center', color: Colors[colorScheme].text }}>
-            Удалить сообщение
-          </Text>
+          <Text style={{ textAlign: 'center' }}>Удалить сообщение</Text>
         </Pressable>
         <Pressable
           onPress={exitChat}
@@ -112,9 +111,7 @@ export default function Chat() {
             backgroundColor: Colors[colorScheme].primary,
           }}
         >
-          <Text style={{ textAlign: 'center', color: Colors[colorScheme].text }}>
-            Выход из чата
-          </Text>
+          <Text style={{ textAlign: 'center' }}>Выход из чата</Text>
         </Pressable>
       </View>
       <FlatList
@@ -162,7 +159,7 @@ export default function Chat() {
           onPress={send}
           style={{ padding: 12, borderRadius: 12, backgroundColor: Colors[colorScheme].primary }}
         >
-          <Text style={{ color: Colors[colorScheme].text }}>Отправить</Text>
+          <Text>Отправить</Text>
         </Pressable>
       </View>
     </View>

--- a/components/ChatSection.tsx
+++ b/components/ChatSection.tsx
@@ -1,8 +1,9 @@
 import React from 'react';
-import { FlatList, TextInput, View, Text, StyleSheet } from 'react-native';
+import { FlatList, TextInput, StyleSheet } from 'react-native';
 import Colors from '@/constants/Colors';
 import { useColorScheme } from './useColorScheme';
 import Button from './ui/Button';
+import { Text, View } from './Themed';
 
 interface Message {
   id: string;

--- a/components/Sidebar.tsx
+++ b/components/Sidebar.tsx
@@ -1,7 +1,8 @@
-import { View, Text, Pressable, StyleSheet } from 'react-native';
+import { Pressable, StyleSheet } from 'react-native';
 import { Link, usePathname } from 'expo-router';
 import Colors from '@/constants/Colors';
 import { useColorScheme } from './useColorScheme';
+import { Text, View } from './Themed';
 
 const items = [
   { href: '/', label: 'Discover' },
@@ -23,9 +24,7 @@ export default function Sidebar() {
             <Pressable
               style={[styles.item, active && { backgroundColor: Colors[colorScheme].sidebarActive }]}
             >
-              <Text style={[styles.itemText, { color: Colors[colorScheme].text }]}>
-                {item.label}
-              </Text>
+              <Text style={styles.itemText}>{item.label}</Text>
             </Pressable>
           </Link>
         );

--- a/components/ui/Button.tsx
+++ b/components/ui/Button.tsx
@@ -1,6 +1,7 @@
-import { Pressable, Text, ViewStyle, useWindowDimensions } from 'react-native';
+import { Pressable, ViewStyle, useWindowDimensions } from 'react-native';
 import Colors from '@/constants/Colors';
 import { useColorScheme } from '../useColorScheme';
+import { Text } from '../Themed';
 
 export default function Button({ title, onPress, style }: { title: string; onPress?: () => void; style?: ViewStyle }) {
   const { width } = useWindowDimensions();
@@ -23,7 +24,7 @@ export default function Button({ title, onPress, style }: { title: string; onPre
         style,
       ]}
     >
-      <Text style={{ fontWeight: '600', color: Colors[colorScheme].text }}>{title}</Text>
+      <Text style={{ fontWeight: '600' }}>{title}</Text>
     </Pressable>
   );
 }

--- a/components/ui/Card.tsx
+++ b/components/ui/Card.tsx
@@ -1,6 +1,7 @@
-import { View, ViewStyle, useWindowDimensions } from 'react-native';
+import { ViewStyle, useWindowDimensions } from 'react-native';
 import Colors from '@/constants/Colors';
 import { useColorScheme } from '../useColorScheme';
+import { View } from '../Themed';
 
 export default function Card({ children, style }: { children: React.ReactNode; style?: ViewStyle }) {
   const { width } = useWindowDimensions();


### PR DESCRIPTION
## Summary
- replace react-native `View`/`Text` imports with Themed variants across screens and components
- remove manual color assignments now provided by the theme

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run lint` *(fails: Missing script "lint")*
- `npx tsc --noEmit` *(fails: Cannot find module '@/lib/mapAgent' or its corresponding type declarations)*

------
https://chatgpt.com/codex/tasks/task_e_68b4cc4eb0188327af58067baf2641cf