### PR TITLE
Use remote image URLs for sample profiles

### DIFF
--- a/lib/sample-data.ts
+++ b/lib/sample-data.ts
@@ -22,4 +22,18 @@ export const sampleProfiles: Profile[] = [
     photos: ['https://example.com/photo3.jpg'],
     coordinates: { lat: 56.838926, lng: 60.605703 },
   },
+  {
+    id: '4',
+    name: 'Дмитрий',
+    bio: 'Занимаюсь программированием и музыкой.',
+    photos: ['https://example.com/photo4.jpg'],
+    coordinates: { lat: 55.008353, lng: 82.935733 },
+  },
+  {
+    id: '5',
+    name: 'Елена',
+    bio: 'Люблю путешествовать и готовить.',
+    photos: ['https://example.com/photo5.jpg'],
+    coordinates: { lat: 55.796289, lng: 49.108795 },
+  },
 ];


### PR DESCRIPTION
## Summary
- remove locally committed profile photos
- reference remote placeholder images in `sampleProfiles`

## Testing
- `npm test` *(fails: Missing script "test")*

------
https://chatgpt.com/codex/tasks/task_e_68b4d24eb98c83279ad82473fe38624c