### PR TITLE
feat: add sample matches data

### DIFF
--- a/lib/sample-matches.ts
+++ b/lib/sample-matches.ts
@@ -1,0 +1,23 @@
+export interface Match {
+  id: string;
+  photo: string;
+  description: string;
+}
+
+export const sampleMatches: Match[] = [
+  {
+    id: '1',
+    photo: 'https://example.com/match1.jpg',
+    description: 'Любит путешествия и кофе.',
+  },
+  {
+    id: '2',
+    photo: 'https://example.com/match2.jpg',
+    description: 'Фанат музыки и кулинарии.',
+  },
+  {
+    id: '3',
+    photo: 'https://example.com/match3.jpg',
+    description: 'Занимается спортом и фотографией.',
+  },
+];


### PR DESCRIPTION
## Summary
- add `Match` interface to define match samples
- provide sample matches with photo URLs and descriptions

## Testing
- `npm test` *(fails: Missing script: "test")*

------
https://chatgpt.com/codex/tasks/task_e_68b4d50be13c832783fb2d5664a5c397