### PR TITLE
Display sample matches grid

### DIFF
--- a/app/(tabs)/matches.tsx
+++ b/app/(tabs)/matches.tsx
@@ -1,9 +1,12 @@
-import { useWindowDimensions } from 'react-native';
+import { useWindowDimensions, FlatList, Image, Pressable } from 'react-native';
 import { Text, View } from '@/components/Themed';
+import { sampleMatches } from '@/lib/sample-matches';
+import { useRouter } from 'expo-router';
 
 export default function Matches() {
   const { width } = useWindowDimensions();
   const isDesktop = width >= 768;
+  const router = useRouter();
 
   return (
     <View
@@ -13,7 +16,29 @@ export default function Matches() {
       ]}
     >
       <Text style={{ fontSize: 24, fontWeight: '600' }}>Matches</Text>
-      <Text style={{ marginTop: 8, opacity: 0.7 }}>Пока пусто</Text>
+      <FlatList
+        data={sampleMatches}
+        keyExtractor={(item) => item.id}
+        renderItem={({ item }) => (
+          <Pressable
+            onPress={() => router.push(`/chat/${item.id}`)}
+            style={{ width: '48%', marginBottom: 16 }}
+          >
+            <Image
+              source={{ uri: item.photo }}
+              style={{ width: '100%', aspectRatio: 1, borderRadius: 12 }}
+            />
+            <Text style={{ marginTop: 8 }}>{item.name}</Text>
+          </Pressable>
+        )}
+        contentContainerStyle={{
+          flexDirection: 'row',
+          flexWrap: 'wrap',
+          justifyContent: 'space-between',
+          marginTop: 16,
+        }}
+      />
     </View>
   );
 }
+

--- a/lib/sample-matches.ts
+++ b/lib/sample-matches.ts
@@ -1,5 +1,6 @@
 export interface Match {
   id: string;
+  name: string;
   photo: string;
   description: string;
 }
@@ -7,16 +8,19 @@ export interface Match {
 export const sampleMatches: Match[] = [
   {
     id: '1',
+    name: 'Анна',
     photo: 'https://example.com/match1.jpg',
     description: 'Любит путешествия и кофе.',
   },
   {
     id: '2',
+    name: 'Борис',
     photo: 'https://example.com/match2.jpg',
     description: 'Фанат музыки и кулинарии.',
   },
   {
     id: '3',
+    name: 'Мария',
     photo: 'https://example.com/match3.jpg',
     description: 'Занимается спортом и фотографией.',
   },


### PR DESCRIPTION
## Summary
- import and render sampleMatches with photos and names in Matches tab
- add sample names to sample match data

## Testing
- `npm test` *(fails: Missing script "test")*

------
https://chatgpt.com/codex/tasks/task_e_68b4d56629c48327ba459c74d70cf968