### PR TITLE
feat: display match profile and AI chat replies

### DIFF
--- a/lib/api.ts
+++ b/lib/api.ts
@@ -52,3 +52,11 @@ export async function aiIcebreaker(matchId: string) {
   if (error) throw error;
   return (data as { icebreaker: string }).icebreaker;
 }
+
+export async function aiChatResponse(matchId: string, message: string) {
+  const { data, error } = await supabase.functions.invoke('ai/chat', {
+    body: { matchId, message },
+  });
+  if (error) throw error;
+  return (data as { reply: string }).reply;
+}


### PR DESCRIPTION
## Summary
- load match profile from sampleProfiles and render photos, name and bio in chat screen
- add new aiChatResponse API and wire it to send message flow for AI replies

## Testing
- `npx tsc -p tsconfig.json --noEmit` (fails: Cannot find module '@/lib/mapAgent' or its corresponding type declarations)
- `npm test` (fails: Missing script: "test")

------
https://chatgpt.com/codex/tasks/task_e_68b4d668a05c83278d0fe639d0035ecc