### PR TITLE
Expand demo messages to cover all matches

### DIFF
--- a/lib/sample-messages.ts
+++ b/lib/sample-messages.ts
@@ -35,4 +35,18 @@ export const sampleMessages: Message[] = [
     content: 'Да, очень!',
     created_at: '2024-01-02T09:10:00Z',
   },
+  {
+    id: '5',
+    match_id: '3',
+    sender: 'user1',
+    content: 'Привет, Мария! Чем занимаешься?',
+    created_at: '2024-01-03T08:00:00Z',
+  },
+  {
+    id: '6',
+    match_id: '3',
+    sender: 'user4',
+    content: 'Привет! Сейчас иду на тренировку.',
+    created_at: '2024-01-03T08:05:00Z',
+  },
 ];


### PR DESCRIPTION
## Summary
- add sample messages for third match
- ensure chat demo loads messages for every match

## Testing
- `npm test` (fails: Missing script "test")
- `npx ts-node --compiler-options '{"module":"commonjs","noImplicitAny":false}' -e "const { sampleMessages } = require('./lib/sample-messages'); console.log(sampleMessages.filter(m => m.match_id === '3'))"`


------
https://chatgpt.com/codex/tasks/task_e_68b4d74de550832783737d8c35d8362a