### PR TITLE
Add AI chat to edit profile fields

### DIFF
--- a/app/(tabs)/profile.tsx
+++ b/app/(tabs)/profile.tsx
@@ -7,6 +7,7 @@ import { sampleProfiles } from '../../lib/sample-data';
 import Colors from '@/constants/Colors';
 import { useColorScheme } from '@/components/useColorScheme';
 import { Text, View } from '@/components/Themed';
+import ProfileAIChat from '@/components/ProfileAIChat';
 
 export default function Profile() {
   const { session } = useAuth();
@@ -169,6 +170,7 @@ export default function Profile() {
         multiline
         style={{ backgroundColor: Colors[colorScheme].inputBackground, padding: 12, borderRadius: 12, minHeight: 100 }}
       />
+      <ProfileAIChat onNameChange={setName} onBioChange={setBio} />
       <Button title="Сохранить" onPress={async () => {
         if (!session?.user) return;
         const { error } = await supabase

--- a/components/ProfileAIChat.tsx
+++ b/components/ProfileAIChat.tsx
@@ -1,0 +1,47 @@
+import React, { useEffect, useState } from 'react';
+import ChatSection, { ChatState } from './ChatSection';
+import { View } from './Themed';
+
+interface ProfileAIChatProps {
+  onNameChange: (name: string) => void;
+  onBioChange: (bio: string) => void;
+}
+
+export default function ProfileAIChat({ onNameChange, onBioChange }: ProfileAIChatProps) {
+  const [state, setState] = useState<ChatState>({ messages: [], input: '' });
+
+  useEffect(() => {
+    if (!state.messages.length) return;
+    const last = state.messages[state.messages.length - 1].text.trim();
+    const lower = last.toLowerCase();
+
+    if (lower.startsWith('name:')) {
+      const value = last.slice(5).trim();
+      onNameChange(value);
+      setState((prev) => ({
+        ...prev,
+        messages: [
+          ...prev.messages,
+          { id: Date.now().toString(), text: `Имя обновлено на \"${value}\"` },
+        ],
+      }));
+    } else if (lower.startsWith('bio:')) {
+      const value = last.slice(4).trim();
+      onBioChange(value);
+      setState((prev) => ({
+        ...prev,
+        messages: [
+          ...prev.messages,
+          { id: Date.now().toString(), text: 'Био обновлено.' },
+        ],
+      }));
+    }
+  }, [state.messages, onNameChange, onBioChange]);
+
+  return (
+    <View style={{ height: 200 }}>
+      <ChatSection state={state} setState={setState} />
+    </View>
+  );
+}
+


### PR DESCRIPTION
## Summary
- add `ProfileAIChat` component that listens for `name:` and `bio:` commands and updates profile fields
- render `ProfileAIChat` beneath profile inputs to allow editing via chat

## Testing
- `npm test` *(fails: Missing script: "test")*
- `npx tsc -p tsconfig.json --noEmit` *(fails: Cannot find module '@/lib/mapAgent' ...)*

------
https://chatgpt.com/codex/tasks/task_e_68b4dd2fb4fc8327a1946f1cf5ee8914