### PR TITLE
feat: allow AI chat to gather profile facts

### DIFF
--- a/app/(tabs)/profile.tsx
+++ b/app/(tabs)/profile.tsx
@@ -14,6 +14,7 @@ export default function Profile() {
   const [photoUrl, setPhotoUrl] = useState<string | null>(null);
   const [name, setName] = useState('');
   const [bio, setBio] = useState('');
+  const [facts, setFacts] = useState<string[]>([]);
   const { width } = useWindowDimensions();
   const isDesktop = width >= 768;
   const colorScheme = useColorScheme() ?? 'light';
@@ -170,7 +171,14 @@ export default function Profile() {
         multiline
         style={{ backgroundColor: Colors[colorScheme].inputBackground, padding: 12, borderRadius: 12, minHeight: 100 }}
       />
-      <ProfileAIChat onNameChange={setName} onBioChange={setBio} />
+      {facts.length > 0 && (
+        <View style={{ gap: 4 }}>
+          {facts.map((fact, idx) => (
+            <Text key={idx}>• {fact}</Text>
+          ))}
+        </View>
+      )}
+      <ProfileAIChat onNameChange={setName} onBioChange={setBio} onFactsChange={setFacts} />
       <Button title="Сохранить" onPress={async () => {
         if (!session?.user) return;
         const { error } = await supabase

--- a/components/ProfileAIChat.tsx
+++ b/components/ProfileAIChat.tsx
@@ -1,14 +1,65 @@
 import React, { useEffect, useState } from 'react';
 import ChatSection, { ChatState } from './ChatSection';
 import { View } from './Themed';
+import Button from './ui/Button';
 
 interface ProfileAIChatProps {
   onNameChange: (name: string) => void;
   onBioChange: (bio: string) => void;
+  onFactsChange?: (facts: string[]) => void;
 }
 
-export default function ProfileAIChat({ onNameChange, onBioChange }: ProfileAIChatProps) {
+export default function ProfileAIChat({ onNameChange, onBioChange, onFactsChange }: ProfileAIChatProps) {
   const [state, setState] = useState<ChatState>({ messages: [], input: '' });
+  const [facts, setFacts] = useState<string[]>([]);
+  const [questionIndex, setQuestionIndex] = useState(0);
+  const [asking, setAsking] = useState(false);
+  const [awaitingAnswer, setAwaitingAnswer] = useState(false);
+
+  const questions = [
+    'Как тебя зовут?',
+    'Сколько тебе лет?',
+    'Чем ты увлекаешься?'
+  ];
+
+  useEffect(() => {
+    if (!asking || awaitingAnswer || questionIndex >= questions.length) return;
+    const question = questions[questionIndex];
+    setState((prev) => ({
+      ...prev,
+      messages: [...prev.messages, { id: Date.now().toString(), text: `AI: ${question}` }],
+    }));
+    setAwaitingAnswer(true);
+  }, [asking, awaitingAnswer, questionIndex, questions]);
+
+  useEffect(() => {
+    if (!asking || !awaitingAnswer || !state.messages.length) return;
+    const last = state.messages[state.messages.length - 1].text;
+    if (last.startsWith('AI:')) return;
+    const answer = last.trim();
+    const newFacts = [...facts, answer];
+    setFacts(newFacts);
+    onFactsChange?.(newFacts);
+    setAwaitingAnswer(false);
+    setQuestionIndex((prev) => prev + 1);
+  }, [state.messages, asking, awaitingAnswer, facts, onFactsChange]);
+
+  useEffect(() => {
+    if (asking && !awaitingAnswer && questionIndex >= questions.length) {
+      setAsking(false);
+      setState((prev) => ({
+        ...prev,
+        messages: [...prev.messages, { id: Date.now().toString(), text: 'AI: Спасибо за ответы!' }],
+      }));
+    }
+  }, [asking, awaitingAnswer, questionIndex, questions.length]);
+
+  const startAsking = () => {
+    setFacts([]);
+    onFactsChange?.([]);
+    setQuestionIndex(0);
+    setAsking(true);
+  };
 
   useEffect(() => {
     if (!state.messages.length) return;
@@ -40,7 +91,11 @@ export default function ProfileAIChat({ onNameChange, onBioChange }: ProfileAICh
 
   return (
     <View style={{ height: 200 }}>
-      <ChatSection state={state} setState={setState} />
+      <ChatSection
+        state={state}
+        setState={setState}
+        extra={!asking ? <Button title="Разрешить ИИ порасспрашивать" onPress={startAsking} /> : undefined}
+      />
     </View>
   );
 }


### PR DESCRIPTION
## Summary
- track facts in `ProfileAIChat` and let AI ask follow-up questions
- show collected facts on the profile page

## Testing
- `npm test` *(fails: Missing script "test")*


------
https://chatgpt.com/codex/tasks/task_e_68b4de30cdbc8327a8aab66346b062be